### PR TITLE
[ouroboros] add_test: Add unit tests in tests/test_backends.py to verify that _git

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -222,6 +222,17 @@ def test_agent_generate_changes_captures_diff_and_resets(monkeypatch, git_repo):
     assert (git_repo / "untracked.txt").read_text() == "keep me\n"
 
 
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("R  old.py -> new.py", "new.py"),
+        ('R  "old name.py" -> "new name.py"', "new name.py"),
+    ],
+)
+def test_git_porcelain_target_path_extracts_rename_destination(line, expected):
+    assert backends._git_porcelain_target_path(line) == expected
+
+
 def test_collect_changes_decodes_quoted_porcelain_paths(monkeypatch, tmp_path):
     rel_path = 'src/space "quote" \\ \u00e9.py'
     target = tmp_path / rel_path


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: add_test
**Task ID**: 11871d4d

### Description
Add unit tests in tests/test_backends.py to verify that _git_porcelain_target_path correctly parses renamed status lines (e.g., 'R  old.py -> new.py' and quoted variants like 'R  "old name.py" -> "new name.py"') and correctly extracts the target destination path.

### Evidence
_git_porcelain_target_path in src/ouroboros/backends.py contains parsing logic to handle rename and copy markers ('R' and 'C') via ' -> ' splitting, but tests/test_backends.py lacks any unit tests exercising these conditions.

### Changes
- `tests/test_backends.py`: Agent edit: tests/test_backends.py

### Test Results
- **Before**: 219 passed, 0 failed, 0 errors (returncode=0), coverage=59.0%
- **After**: 221 passed, 0 failed, 0 errors (returncode=0), coverage=59.0%

---
Generated autonomously by Ouroboros self-improvement engine.