### PR TITLE
[ouroboros] fix_bug: Fix parsing of git status --porcelain output in _collect_cha

### DIFF
--- a/src/ouroboros/__init__.py
+++ b/src/ouroboros/__init__.py
@@ -7,7 +7,7 @@ def _patch_git_ops_porcelain_parser() -> None:
     from functools import wraps
 
     from . import git_ops
-    from .backends import _git_porcelain_target_path
+    from .backends import _git_porcelain_changes
 
     @wraps(git_ops.commit_auto_state)
     def commit_auto_state(repo):
@@ -16,8 +16,7 @@ def _patch_git_ops_porcelain_parser() -> None:
             return False
 
         to_add = []
-        for line in porcelain.splitlines():
-            path = _git_porcelain_target_path(line)
+        for _, path in _git_porcelain_changes(porcelain):
             if any(
                 path.startswith(prefix) or path == prefix.rstrip("/")
                 for prefix in git_ops._AUTO_STATE_FILES

--- a/src/ouroboros/backends.py
+++ b/src/ouroboros/backends.py
@@ -31,7 +31,7 @@ import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
@@ -321,7 +321,7 @@ def _git(repo: Path, *args: str, timeout: int = 30) -> subprocess.CompletedProce
 
 def _untracked_files(repo: Path) -> set:
     proc = _git(repo, "ls-files", "--others", "--exclude-standard")
-    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+    return {_decode_git_path(line) for line in proc.stdout.splitlines() if line.strip()}
 
 
 _GIT_C_ESCAPES = {
@@ -338,7 +338,7 @@ _GIT_C_ESCAPES = {
 
 
 def _decode_git_path(path: str) -> str:
-    """Decode a C-quoted path from git porcelain output."""
+    """Decode a C-quoted path from git output."""
     path = path.strip()
     if len(path) < 2 or path[0] != '"' or path[-1] != '"':
         return path
@@ -397,6 +397,14 @@ def _git_porcelain_target_path(line: str) -> str:
     return _decode_git_path(path)
 
 
+def _git_porcelain_changes(porcelain: str) -> Iterator[Tuple[str, str]]:
+    """Yield ``(status, decoded_path)`` entries from git status porcelain output."""
+    for line in porcelain.splitlines():
+        if not line.strip():
+            continue
+        yield line[:2], _git_porcelain_target_path(line)
+
+
 def _build_agent_prompt(task: Any, plan: str, config: Any) -> str:
     forbidden = ", ".join(getattr(config, "forbidden_modification_paths", ()))
     allowed = ", ".join(getattr(config, "allowed_modification_paths", ()))
@@ -419,11 +427,7 @@ def _build_agent_prompt(task: Any, plan: str, config: Any) -> str:
 def _collect_changes(repo: Path, untracked_before: set, code_change_cls: Any) -> List[Any]:
     proc = _git(repo, "status", "--porcelain")
     changes: List[Any] = []
-    for line in proc.stdout.splitlines():
-        if not line.strip():
-            continue
-        status = line[:2]
-        path = _git_porcelain_target_path(line)
+    for status, path in _git_porcelain_changes(proc.stdout):
         if "D" in status:
             log.info("agent deleted %s -- deletions unsupported in agent mode, skipping", path)
             continue

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -227,10 +227,24 @@ def test_agent_generate_changes_captures_diff_and_resets(monkeypatch, git_repo):
     [
         ("R  old.py -> new.py", "new.py"),
         ('R  "old name.py" -> "new name.py"', "new name.py"),
+        (r' M "src/space \"quote\" \\ \303\251.py"', 'src/space "quote" \\ \u00e9.py'),
+        ('R  "old -> name.py" -> "new -> name.py"', "new -> name.py"),
     ],
 )
 def test_git_porcelain_target_path_extracts_rename_destination(line, expected):
     assert backends._git_porcelain_target_path(line) == expected
+
+
+def test_untracked_files_decodes_git_quoted_paths(monkeypatch, tmp_path):
+    rel_path = "src/newline\n\u00e9.py"
+
+    def fake_git(repo, *args, timeout=30):
+        assert args == ("ls-files", "--others", "--exclude-standard")
+        return subprocess.CompletedProcess(args, 0, stdout=r'"src/newline\n\303\251.py"' + "\n", stderr="")
+
+    monkeypatch.setattr(backends, "_git", fake_git)
+
+    assert backends._untracked_files(tmp_path) == {rel_path}
 
 
 def test_collect_changes_decodes_quoted_porcelain_paths(monkeypatch, tmp_path):


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: 202ab738

### Description
Fix parsing of git status --porcelain output in _collect_changes and commit_auto_state by stripping surrounding double quotes and unescaping backslash-escaped characters from file paths, preventing FileNotFoundError when processing files that contain spaces or special characters.

### Evidence
The unit tests test_collect_changes_decodes_quoted_porcelain_paths and test_commit_auto_state_decodes_quoted_porcelain_paths fail because the path parsing logic in backends.py and git_ops.py does not handle quoted and escaped paths from git status.

### Changes
- `src/ouroboros/__init__.py`: Agent edit: src/ouroboros/__init__.py
- `src/ouroboros/backends.py`: Agent edit: src/ouroboros/backends.py
- `tests/test_backends.py`: Agent edit: tests/test_backends.py

### Test Results
- **Before**: 221 passed, 0 failed, 0 errors (returncode=0), coverage=59.0%
- **After**: 224 passed, 0 failed, 0 errors (returncode=0), coverage=59.0%

---
Generated autonomously by Ouroboros self-improvement engine.