### PR TITLE
[ouroboros] add_feature: Modify extract_code_metadata in src/ouroboros/codebase.py to

### DIFF
--- a/src/ouroboros/codebase.py
+++ b/src/ouroboros/codebase.py
@@ -54,7 +54,7 @@ def extract_code_metadata(content: str, path: str = "") -> FileMetadata:
                 metadata.imports.append(node.module or "")
 
     for node in tree.body:
-        if isinstance(node, ast.FunctionDef):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             metadata.functions.append(FunctionMetadata(
                 name=node.name,
                 args=[arg.arg for arg in node.args.args],
@@ -70,7 +70,7 @@ def extract_code_metadata(content: str, path: str = "") -> FileMetadata:
                 line_end=getattr(node, "end_lineno", node.lineno)
             )
             for subnode in node.body:
-                if isinstance(subnode, ast.FunctionDef):
+                if isinstance(subnode, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     cls.methods.append(FunctionMetadata(
                         name=subnode.name,
                         args=[arg.arg for arg in subnode.args.args],

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -4,6 +4,7 @@ import textwrap
 from pathlib import Path
 
 from ouroboros.codebase import (
+    extract_code_metadata,
     get_function_signatures,
     get_repo_root,
     list_source_files,
@@ -93,12 +94,64 @@ def test_get_function_signatures_syntax_error(tmp_path):
     assert sigs == [], "Syntax error should result in no signatures being returned."
 
 
+def test_extract_code_metadata_async_functions_and_methods():
+    code = textwrap.dedent('''
+        async def fetch_value(client):
+            """Fetch a value asynchronously."""
+            return await client.fetch()
+
+        class Service:
+            async def refresh(self, key):
+                """Refresh one key."""
+                return key
+
+            def sync_method(self):
+                return None
+    ''').lstrip()
+
+    metadata = extract_code_metadata(code, "service.py")
+
+    assert [func.name for func in metadata.functions] == ["fetch_value"]
+    assert metadata.functions[0].args == ["client"]
+    assert metadata.functions[0].docstring == "Fetch a value asynchronously."
+
+    assert len(metadata.classes) == 1
+    service = metadata.classes[0]
+    assert service.name == "Service"
+    assert [method.name for method in service.methods] == ["refresh", "sync_method"]
+
+    refresh = service.methods[0]
+    assert refresh.args == ["self", "key"]
+    assert refresh.docstring == "Refresh one key."
+
+
 def test_get_codebase_summary():
     summary = get_codebase_summary()
     assert '# Codebase Summary' in summary
     assert 'Source Files' in summary
     assert 'Test Files' in summary
     assert 'config.py' in summary
+
+
+def test_get_codebase_summary_includes_async_metadata(tmp_path):
+    src_dir = tmp_path / 'src' / 'ouroboros'
+    tests_dir = tmp_path / 'tests'
+    src_dir.mkdir(parents=True)
+    tests_dir.mkdir()
+    (src_dir / 'async_module.py').write_text(textwrap.dedent('''
+        async def fetch_value(client):
+            return await client.fetch()
+
+        class Service:
+            async def refresh(self, key):
+                return key
+    ''').lstrip())
+
+    summary = get_codebase_summary(tmp_path)
+
+    assert 'async_module.py' in summary
+    assert 'def fetch_value(client)' in summary
+    assert 'def refresh(self, key)' in summary
 
 
 def test_list_source_files_nonexistent(tmp_path):


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: add_feature
**Task ID**: 39a17d23

### Description
Modify extract_code_metadata in src/ouroboros/codebase.py to recognize ast.AsyncFunctionDef nodes in addition to ast.FunctionDef, so that async functions and methods are correctly extracted into FileMetadata and included in the codebase summary. Add corresponding unit tests in tests/test_codebase.py.

### Evidence
In src/ouroboros/codebase.py, extract_code_metadata only checks for ast.FunctionDef when parsing module-level functions and class-level methods, which leaves ast.AsyncFunctionDef nodes completely ignored and missing from get_codebase_summary output.

### Changes
- `src/ouroboros/codebase.py`: Agent edit: src/ouroboros/codebase.py
- `tests/test_codebase.py`: Agent edit: tests/test_codebase.py

### Test Results
- **Before**: 224 passed, 0 failed, 0 errors (returncode=0), coverage=59.0%
- **After**: 226 passed, 0 failed, 0 errors (returncode=0), coverage=59.0%

---
Generated autonomously by Ouroboros self-improvement engine.