### PR TITLE
[ouroboros] fix_bug: Fix backlog duplicate checking in add_item within src/ourobo

### DIFF
--- a/src/ouroboros/backlog.py
+++ b/src/ouroboros/backlog.py
@@ -49,9 +49,9 @@ def add_item(
     source: str = "auto",
 ) -> Dict[str, Any]:
     items = load_backlog(repo_root)
-    # Dedup by description similarity
+    # Dedup pending items by description similarity
     for item in items:
-        if item.get("description") == description:
+        if item.get("description") == description and item.get("status") == "pending":
             return item
 
     entry = {

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -55,6 +55,33 @@ class TestBacklog:
         items = load_backlog(self.tmp_dir)
         assert len(items) == 1
 
+    def test_add_duplicate_item_done(self):
+        desc = "repeat completed task"
+        first = add_item(self.tmp_dir, "feat", desc)
+        mark_done(self.tmp_dir, first["id"])
+
+        second = add_item(self.tmp_dir, "feat", desc)
+
+        items = load_backlog(self.tmp_dir)
+        assert len(items) == 2
+        assert items[0]["status"] == "done"
+        assert items[1]["status"] == "pending"
+        assert second["id"] != first["id"]
+
+    def test_add_duplicate_item_abandoned(self):
+        desc = "repeat abandoned task"
+        first = add_item(self.tmp_dir, "fix", desc)
+        for _ in range(3):
+            mark_failed(self.tmp_dir, first["id"])
+
+        second = add_item(self.tmp_dir, "fix", desc)
+
+        items = load_backlog(self.tmp_dir)
+        assert len(items) == 2
+        assert items[0]["status"] == "abandoned"
+        assert items[1]["status"] == "pending"
+        assert second["id"] != first["id"]
+
     def test_mark_done(self):
         entry = add_item(self.tmp_dir, "fix", "fix bug")
         mark_done(self.tmp_dir, entry["id"])


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: 6ba176b4

### Description
Fix backlog duplicate checking in add_item within src/ouroboros/backlog.py to only match existing items if their status is 'pending', allowing completed or abandoned tasks to be re-added to the backlog.

### Evidence
In src/ouroboros/backlog.py, add_item rejects any task with a matching description and task_type regardless of status, preventing previously completed or abandoned tasks from ever being re-added to the backlog.

### Changes
- `src/ouroboros/backlog.py`: Agent edit: src/ouroboros/backlog.py
- `tests/test_backlog.py`: Agent edit: tests/test_backlog.py

### Test Results
- **Before**: 243 passed, 0 failed, 0 errors (returncode=0), coverage=61.0%
- **After**: 245 passed, 0 failed, 0 errors (returncode=0), coverage=61.0%

---
Generated autonomously by Ouroboros self-improvement engine.