### PR TITLE
[ouroboros] fix_bug: Fix bundle function in src/ouroboros/holographic.py to valid

### DIFF
--- a/src/ouroboros/holographic.py
+++ b/src/ouroboros/holographic.py
@@ -62,6 +62,8 @@ def unbind(memory: "np.ndarray", key: "np.ndarray") -> "np.ndarray":
 def bundle(*vectors: "np.ndarray") -> "np.ndarray":
     """Superposition via circular mean of complex exponentials."""
     _require_numpy()
+    if not vectors:
+        raise ValueError("At least one vector must be provided to bundle")
     complex_sum = np.sum([np.exp(1j * v) for v in vectors], axis=0)
     return np.angle(complex_sum) % _TWO_PI
 

--- a/tests/test_holographic.py
+++ b/tests/test_holographic.py
@@ -57,6 +57,10 @@ def test_bundle():
     d = encode_atom("dog", dim=128)
     assert similarity(bundled, d) < similarity(bundled, a)
 
+def test_bundle_empty():
+    with pytest.raises(ValueError, match="At least one vector must be provided to bundle"):
+        bundle()
+
 def test_similarity():
     a = encode_atom("cat", dim=64)
     b = encode_atom("cat", dim=64)


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: 0c6f720a

### Description
Fix bundle function in src/ouroboros/holographic.py to validate that at least one vector is provided and raise ValueError when called with empty vectors.

### Evidence
In src/ouroboros/holographic.py, bundle() called without arguments computes np.sum([]) returning scalar float 0.0 instead of a numpy phase vector or raising ValueError.

### Changes
- `src/ouroboros/holographic.py`: Agent edit: src/ouroboros/holographic.py
- `tests/test_holographic.py`: Agent edit: tests/test_holographic.py

### Test Results
- **Before**: 246 passed, 0 failed, 0 errors (returncode=0), coverage=61.0%
- **After**: 247 passed, 0 failed, 0 errors (returncode=0), coverage=61.0%

---
Generated autonomously by Ouroboros self-improvement engine.