### PR TITLE
[ouroboros] fix_bug: Fix _parse_pytest_output in src/ouroboros/test_runner.py to 

### DIFF
--- a/src/ouroboros/test_runner.py
+++ b/src/ouroboros/test_runner.py
@@ -72,8 +72,8 @@ def _parse_pytest_output(output: str) -> dict:
     if cov_match:
         result["coverage"] = float(cov_match.group(1))
 
-    # Parse FAILED lines like "FAILED tests/test_foo.py::test_bar - AssertionError: ..."
-    for match in re.finditer(r"FAILED\s+([\w/._-]+)::(\S+)\s*(?:-\s*(.*))?", output):
+    # Parse FAILED/ERROR lines like "FAILED tests/test_foo.py::test_bar - AssertionError: ..."
+    for match in re.finditer(r"(?:FAILED|ERROR)\s+([\w/._-]+)::(\S+)\s*(?:-\s*(.*))?", output):
         file_path = match.group(1)
         test_name = match.group(2)
         message = match.group(3) or ""

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -45,6 +45,36 @@ FAILED tests/test_foo.py::test_bar - AssertionError: expected 1 got 2
     assert fail.file == "tests/test_foo.py"
     assert "AssertionError" in fail.message
 
+def test_parse_pytest_output_error_details():
+    output = """
+ERROR tests/test_foo.py::test_setup - RuntimeError: fixture failed
+3 passed, 1 error in 0.52s
+"""
+    result = _parse_pytest_output(output)
+    assert result["errors"] == 1
+    assert len(result["failures"]) == 1
+    fail = result["failures"][0]
+    assert fail.test_name == "test_setup"
+    assert fail.file == "tests/test_foo.py"
+    assert fail.message == "RuntimeError: fixture failed"
+
+def test_parse_pytest_output_mixed_failures_and_errors():
+    output = """
+FAILED tests/test_foo.py::test_bar - AssertionError: expected 1 got 2
+ERROR tests/test_bar.py::test_setup - RuntimeError: fixture failed
+2 passed, 1 failed, 1 error in 0.52s
+"""
+    result = _parse_pytest_output(output)
+    assert result["failed"] == 1
+    assert result["errors"] == 1
+    assert len(result["failures"]) == 2
+    assert [fail.test_name for fail in result["failures"]] == ["test_bar", "test_setup"]
+    assert [fail.file for fail in result["failures"]] == ["tests/test_foo.py", "tests/test_bar.py"]
+    assert [fail.message for fail in result["failures"]] == [
+        "AssertionError: expected 1 got 2",
+        "RuntimeError: fixture failed",
+    ]
+
 def test_parse_pytest_output_no_tests():
     output = "no tests ran in 0.01s"
     result = _parse_pytest_output(output)


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: 0a5b2525

### Description
Fix _parse_pytest_output in src/ouroboros/test_runner.py to match both FAILED and ERROR lines in pytest output so fixture, setup, and teardown errors are included in failure_details.

### Evidence
In src/ouroboros/test_runner.py at line 76, _parse_pytest_output uses regex r'FAILED\s+...' which ignores pytest 'ERROR' lines (e.g., ERROR tests/test_foo.py::test_bar - Exception: ...), resulting in empty failure_details for test errors.

### Changes
- `src/ouroboros/test_runner.py`: Agent edit: src/ouroboros/test_runner.py
- `tests/test_test_runner.py`: Agent edit: tests/test_test_runner.py

### Test Results
- **Before**: 247 passed, 0 failed, 0 errors (returncode=0), coverage=61.0%
- **After**: 249 passed, 0 failed, 0 errors (returncode=0), coverage=61.0%

---
Generated autonomously by Ouroboros self-improvement engine.