### PR TITLE
fix(tests): make os.path.exists mocks py3.14-safe; test on 3.13/3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -28,8 +28,12 @@ def test_load_key_from_file(tmp_path):
                 return str(tmp_path / "openai.json")
             return path
 
+        orig_exists = os.path.exists
+
         def fake_exists(path):
-            return path == str(cfg)
+            if os.fspath(path) == str(cfg):
+                return True
+            return orig_exists(path)
 
         with mock.patch("ouroboros.llm.os.path.expanduser", side_effect=fake_expanduser):
             with mock.patch("ouroboros.llm.os.path.exists", side_effect=fake_exists):
@@ -48,8 +52,12 @@ def test_load_key_does_not_use_moltbook_api_key(tmp_path):
                 return str(tmp_path / "openai.json")
             return path
 
+        orig_exists = os.path.exists
+
         def fake_exists(path):
-            return path == str(cfg)
+            if os.fspath(path) == str(cfg):
+                return True
+            return orig_exists(path)
 
         with mock.patch("ouroboros.llm.os.path.expanduser", side_effect=fake_expanduser):
             with mock.patch("ouroboros.llm.os.path.exists", side_effect=fake_exists):
@@ -69,8 +77,12 @@ def test_load_key_from_legacy_file(tmp_path):
                 return str(legacy)
             return path
 
+        orig_exists = os.path.exists
+
         def fake_exists(path):
-            return path == str(legacy)
+            if os.fspath(path) == str(legacy):
+                return True
+            return orig_exists(path)
 
         with mock.patch("ouroboros.llm.os.path.expanduser", side_effect=fake_expanduser):
             with mock.patch("ouroboros.llm.os.path.exists", side_effect=fake_exists):

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -104,8 +104,12 @@ def test_load_runner_config_from_file(tmp_path):
             return str(cred_file)
         return path
 
+    orig_exists = os.path.exists
+
     def fake_exists(path):
-        return path == str(cfg_file)
+        if os.fspath(path) == str(cfg_file):
+            return True
+        return orig_exists(path)
 
     with mock.patch("ouroboros.moltbook.os.path.expanduser", side_effect=fake_expanduser):
         with mock.patch("ouroboros.moltbook.os.path.exists", side_effect=fake_exists):
@@ -129,8 +133,12 @@ def test_load_runner_config_uses_legacy_self_improve_interval(tmp_path):
             return str(cfg_file)
         return path
 
+    orig_exists = os.path.exists
+
     def fake_exists(path):
-        return path == str(cfg_file)
+        if os.fspath(path) == str(cfg_file):
+            return True
+        return orig_exists(path)
 
     with mock.patch("ouroboros.moltbook.os.path.expanduser", side_effect=fake_expanduser):
         with mock.patch("ouroboros.moltbook.os.path.exists", side_effect=fake_exists):
@@ -159,8 +167,12 @@ def test_load_runner_config_telegram_from_credentials(tmp_path):
             return str(cred_file)
         return path
 
+    orig_exists = os.path.exists
+
     def fake_exists(path):
-        return path in {str(cfg_file), str(cred_file)}
+        if os.fspath(path) in {str(cfg_file), str(cred_file)}:
+            return True
+        return orig_exists(path)
 
     with mock.patch.dict(os.environ, {}, clear=True):
         with mock.patch("ouroboros.moltbook.os.path.expanduser", side_effect=fake_expanduser):


### PR DESCRIPTION
## Problem

The test suite fails on Python 3.14 with 3 errors in `tests/test_moltbook.py`:

```
FAILED tests/test_moltbook.py::test_load_runner_config_from_file - FileNotFoundError
FAILED tests/test_moltbook.py::test_load_runner_config_uses_legacy_self_improve_interval
FAILED tests/test_moltbook.py::test_load_runner_config_telegram_from_credentials
```

**Root cause.** On 3.14 `pathlib.Path.exists()` delegates to `os.path.exists`, passing the `Path` object itself. These tests patch `ouroboros.moltbook.os.path.exists` — which resolves to the *global* `os` module, not a module-local name — with a fake comparing its argument to a `str` via `==`. That comparison fails on type, so the mock returns `False`, and the patch leaks out of the code under test into `storage.load_json_file`. `load_runner_config` then raises `FileNotFoundError` instead of falling back to defaults.

Verified directly:

```python
with mock.patch("os.path.exists", side_effect=lambda p: False):
    pathlib.Path(existing_file).exists()   # -> False on 3.14
```

CI only ran 3.10–3.12, so this never surfaced upstream.

## Fix

- Normalize the argument with `os.fspath()` so intended paths match regardless of `str`/`Path`.
- Delegate unmatched paths to the real `os.path.exists` via the `orig_exists` fallback that other mocks in these same files already use.
- Apply the same fix to three sites in `tests/test_llm.py`. Those pass today only because `load_openai_key` happens not to touch pathlib — same latent defect.
- Add 3.13 and 3.14 to the CI matrix so this class of breakage surfaces upstream.

## Deliberately not changed

The two `return_value=False` patches (`test_moltbook.py:187,193`, `test_llm.py`) are version-independent and express "no config file exists anywhere", which is what those tests mean.

## Verification

- `249 passed` on Python 3.14.6 locally (was `246 passed, 3 failed`).
- No source changes — tests and CI config only.

## Review

Reviewed by Codex and Antigravity adversarially. Codex confirmed the fallback is correct and non-recursive, and flagged the `test_llm.py` sites — fixed here. Antigravity suggested the `os.fspath()` normalization — applied. Antigravity also raised that 3.14 is unreleased and may lack wheels; that is out of date (3.14 released Oct 2025, running 3.14.6 locally), and Codex independently verified numpy/pydantic/openai/pytest all support 3.14. The CI matrix in this PR is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm