### PR TITLE
fix(memory): treat search_facts input as literal text, not an FTS5 expression

### DIFF
--- a/src/ouroboros/memory.py
+++ b/src/ouroboros/memory.py
@@ -108,6 +108,28 @@ def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
 
 
+def _fts5_match_query(text: str) -> str:
+    """Compile arbitrary text into a literal FTS5 MATCH expression.
+
+    FTS5 reads its own operators out of the query string, so ordinary text
+    containing a colon, an unbalanced quote, a trailing ``AND`` or a bare
+    ``*`` is a syntax error rather than a search term. Quoting each
+    whitespace-separated token turns it into a phrase, which FTS5 matches
+    literally: ``issue:123`` searches for "issue:123" instead of failing on
+    an unknown column. Embedded double quotes are escaped by doubling.
+
+    Returns "" when the text has no searchable tokens, which callers treat
+    as "no results" without touching the database.
+
+    NUL is replaced rather than quoted: SQLite stops reading the MATCH
+    expression at U+0000, so a quoted phrase containing one is reported as
+    an unterminated string no matter how it is escaped. It is the only
+    control character that survives quoting.
+    """
+    tokens = [token for token in text.replace("\x00", " ").split() if token.strip()]
+    return " ".join('"' + token.replace('"', '""') + '"' for token in tokens)
+
+
 # ---------------------------------------------------------------------------
 # Code indexing
 # ---------------------------------------------------------------------------
@@ -241,12 +263,16 @@ class MemoryStore:
 
     def search_facts(self, query: str, category: Optional[str] = None,
                      min_trust: float = 0.3, limit: int = 10) -> List[Dict]:
-        """Full-text search over facts using FTS5."""
+        """Full-text search over facts using FTS5.
+
+        ``query`` is treated as literal text, not as an FTS5 expression, so
+        arbitrary input is safe to pass through.
+        """
         with self._lock:
-            query = query.strip()
-            if not query:
+            match_query = _fts5_match_query(query)
+            if not match_query:
                 return []
-            params: list = [query, min_trust]
+            params: list = [match_query, min_trust]
             cat_clause = ""
             if category is not None:
                 cat_clause = "AND f.category = ?"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,6 @@
 """Tests for holographic memory and AST-based code indexing."""
 
+import sqlite3
 import tempfile
 from pathlib import Path
 import pytest
@@ -194,6 +195,88 @@ def test_memory_store_crud_entities_search_and_feedback(temp_store):
     assert not temp_store.remove_fact(fact_id)
     with pytest.raises(KeyError):
         temp_store.record_feedback(fact_id, helpful=True)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "col:val",        # unknown column
+        'foo"bar',        # unbalanced double quote
+        '"unclosed',      # unterminated phrase
+        "NEAR/",          # malformed NEAR
+        "*",              # bare special-query prefix
+        "***",
+        '" "',
+    ],
+)
+def test_search_facts_no_hits_for_fts5_syntax_text(temp_store, query):
+    """FTS5 syntax characters in user text must not escape as an exception."""
+    temp_store.add_fact("the cat sat on the mat", category="test")
+
+    assert temp_store.search_facts(query) == []
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("cat:", "the cat sat on the mat"),          # punctuation is a separator
+        ("issue:123", "see issue:123 for details"),  # colon is not a column filter
+        ("http://example.com", "visit http://example.com now"),
+        ("user's manual", "the user's manual"),
+        ("a AND", "a AND b are both listed"),        # AND is not an operator
+    ],
+)
+def test_search_facts_treats_query_as_literal_text(temp_store, query, expected):
+    """Text with FTS5 metacharacters searches literally instead of failing."""
+    for content in (
+        "the cat sat on the mat",
+        "see issue:123 for details",
+        "visit http://example.com now",
+        "the user's manual",
+        "a AND b are both listed",
+    ):
+        temp_store.add_fact(content, category="test")
+
+    assert [r["content"] for r in temp_store.search_facts(query)] == [expected]
+
+
+def test_search_facts_handles_embedded_nul(temp_store):
+    """U+0000 truncates the MATCH expression however it is quoted."""
+    temp_store.add_fact("the cat sat on the mat", category="test")
+
+    assert temp_store.search_facts("\x00") == []
+    assert [r["content"] for r in temp_store.search_facts("cat\x00")] == [
+        "the cat sat on the mat"
+    ]
+    assert [r["content"] for r in temp_store.search_facts("cat\x00mat")] == [
+        "the cat sat on the mat"
+    ]
+
+
+@pytest.mark.parametrize("query", ["", "   ", "\x00", "\x00\x00"])
+def test_search_facts_empty_query_short_circuits(temp_store, query):
+    temp_store.add_fact("the cat sat on the mat", category="test")
+
+    assert temp_store.search_facts(query) == []
+
+
+def test_search_facts_no_hits_does_not_bump_retrieval_count(temp_store):
+    fact_id = temp_store.add_fact("the cat sat on the mat", category="test")
+
+    assert temp_store.search_facts("col:val") == []
+
+    stored = temp_store.list_facts()[0]
+    assert stored["fact_id"] == fact_id
+    assert stored["retrieval_count"] == 0
+
+
+def test_search_facts_propagates_real_database_errors(temp_store):
+    """Infrastructure failures must not be masked as "no results"."""
+    temp_store.add_fact("the cat sat on the mat", category="test")
+    temp_store._conn.execute("DROP TABLE facts_fts")
+
+    with pytest.raises(sqlite3.OperationalError, match="facts_fts"):
+        temp_store.search_facts("cat")
 
 
 def test_fact_retriever_hybrid_search_uses_fts_jaccard_and_hrr(tmp_path):


### PR DESCRIPTION
Closes #45.

## Problem

`MemoryStore.search_facts` passed the caller's text straight into an FTS5 `MATCH`. FTS5 reads its own operators out of that string, so ordinary text raised `sqlite3.OperationalError` out of a plain search call:

```
search_facts("cat:")     -> OperationalError: no such column: cat
search_facts('foo"bar')  -> OperationalError: unterminated string
search_facts("a AND")    -> OperationalError: fts5: syntax error near ""
search_facts("*")        -> OperationalError: unknown special query:
```

## Fix, and why not the one the issue proposed

The issue asked for `try/except sqlite3.OperationalError: return []`. I implemented that first, and adversarial review correctly rejected it on two counts:

1. **It masks real failures.** `OperationalError` also covers `no such table: facts_fts`, `database is locked`, and `database disk image is malformed`. A corrupt or schema-drifted index would be indistinguishable from "no results", and memory retrieval would silently stop working.
2. **It is wrong for merely-punctuated input.** `issue:123`, `http://example.com`, and `user's manual` are real searches. Returning `[]` for them is a silent wrong answer, not a fix.

So instead of catching the error, this compiles the input into a valid FTS5 expression. `_fts5_match_query` quotes each whitespace-separated token as a phrase (doubling embedded quotes), which FTS5 matches literally.

**There is no `try/except` at all**, so genuine database failures propagate to the caller — covered by a test that drops `facts_fts` and asserts `OperationalError` still escapes.

| input | before | with `except: return []` | this PR |
|---|---|---|---|
| `cat:` | raises | `[]` | matches "cat" |
| `issue:123` | raises | `[]` | matches the fact |
| `http://example.com` | raises | `[]` | matches the fact |
| `user's manual` | raises | `[]` | matches the fact |
| `foo"bar`, `*`, `a AND` | raises | `[]` | `[]` |
| `facts_fts` dropped | raises | **`[]` (masked)** | **raises** |

### NUL

`U+0000` is special-cased: SQLite stops reading the MATCH expression at NUL, so a phrase containing one is an unterminated string however it is escaped. It is replaced with a space. A sweep of all 32 control characters in four positions confirms it is the only one that survives quoting.

## Verification

- `268 passed` locally.
- New tests fail against the previous `try/except` approach and pass here.
- Exhaustive sweep: 32 control chars × 4 positions + 14 adversarial FTS5 strings (`"`, `"""`, `NEAR(a b`, `col:*`, `a*b`, …) — none raise.
- Multi-token queries keep implicit-AND semantics; the query stays a bound parameter, so quoting adds no injection path.

## Scope

No production code calls `search_facts` today (tests only), and no caller uses FTS5 operator syntax, so treating the argument as literal text changes no existing behavior.

`FactRetriever._fts_candidates` has the same raw-query issue but already returns `[]` via a blanket `except Exception`. Left alone as out of scope — worth a follow-up, since that blanket catch has the same masking problem described above.

## Review

Reviewed adversarially by Codex and Antigravity across two rounds. Round 1: both rejected the `try/except` approach (error masking + wrong results for punctuated input) — reworked to compilation. Round 2: Antigravity approved; Codex found the NUL counterexample, which I reproduced and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm