### PR TITLE
fix(holographic): reject non-positive dim in encode_atom

### DIFF
--- a/src/ouroboros/holographic.py
+++ b/src/ouroboros/holographic.py
@@ -36,8 +36,16 @@ def _require_numpy() -> None:
 
 
 def encode_atom(word: str, dim: int = 1024) -> "np.ndarray":
-    """Deterministic phase vector via SHA-256 counter blocks."""
+    """Deterministic phase vector via SHA-256 counter blocks.
+
+    Raises ValueError if dim is not positive. A non-positive dim would
+    otherwise yield a length-0 vector that every HRR operation accepts
+    silently -- similarity() on two of them returns nan, which corrupts
+    ranking instead of failing.
+    """
     _require_numpy()
+    if dim <= 0:
+        raise ValueError(f"dim must be positive, got {dim}")
     values_per_block = 16
     blocks_needed = math.ceil(dim / values_per_block)
     uint16_values: list[int] = []

--- a/src/ouroboros/memory.py
+++ b/src/ouroboros/memory.py
@@ -191,6 +191,12 @@ class MemoryStore:
     """SQLite-backed fact store with entity resolution, trust scoring, and HRR vectors."""
 
     def __init__(self, db_path: Optional[Path] = None, hrr_dim: int = 1024) -> None:
+        # Checked here, before the database is touched: add_fact commits the
+        # fact row before computing its HRR vector, so letting a bad hrr_dim
+        # reach encode_atom would leave a committed row with a NULL vector
+        # that the dedup path then reports as a success on retry.
+        if hrr_dim <= 0:
+            raise ValueError(f"hrr_dim must be positive, got {hrr_dim}")
         if db_path is None:
             db_path = get_repo_root() / "config" / "memory.db"
         self.db_path = Path(db_path).expanduser()

--- a/tests/test_holographic.py
+++ b/tests/test_holographic.py
@@ -24,6 +24,30 @@ def test_encode_atom():
     assert np.array_equal(v1, v2)
     assert not np.array_equal(v1, v3)
 
+@pytest.mark.parametrize("dim", [0, -1, -1024])
+def test_encode_atom_rejects_non_positive_dim(dim):
+    with pytest.raises(ValueError, match="dim must be positive"):
+        encode_atom("hello", dim=dim)
+
+def test_encode_atom_accepts_smallest_valid_dim():
+    assert encode_atom("hello", dim=1).shape == (1,)
+
+@pytest.mark.parametrize("dim", [0, -1])
+def test_encode_text_rejects_non_positive_dim(dim):
+    with pytest.raises(ValueError, match="dim must be positive"):
+        encode_text("the cat", dim=dim)
+
+@pytest.mark.parametrize("dim", [0, -1])
+def test_encode_text_rejects_non_positive_dim_when_no_tokens(dim):
+    # The empty-token path takes a different branch to encode_atom.
+    with pytest.raises(ValueError, match="dim must be positive"):
+        encode_text("...", dim=dim)
+
+@pytest.mark.parametrize("dim", [0, -1])
+def test_encode_fact_rejects_non_positive_dim(dim):
+    with pytest.raises(ValueError, match="dim must be positive"):
+        encode_fact("content", ["entity"], dim=dim)
+
 def test_bind_unbind():
     a = encode_atom("key", dim=64)
     b = encode_atom("val", dim=64)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -270,6 +270,17 @@ def test_search_facts_no_hits_does_not_bump_retrieval_count(temp_store):
     assert stored["retrieval_count"] == 0
 
 
+@pytest.mark.parametrize("hrr_dim", [0, -1, -1024])
+def test_memory_store_rejects_non_positive_hrr_dim(tmp_path, hrr_dim):
+    """Reject before touching the DB, so no partial fact row can be committed."""
+    db_path = tmp_path / "bad_dim.db"
+
+    with pytest.raises(ValueError, match="hrr_dim must be positive"):
+        MemoryStore(db_path=db_path, hrr_dim=hrr_dim)
+
+    assert not db_path.exists()
+
+
 def test_search_facts_propagates_real_database_errors(temp_store):
     """Infrastructure failures must not be masked as "no results"."""
     temp_store.add_fact("the cat sat on the mat", category="test")


### PR DESCRIPTION
Closes #44.

## Problem

`encode_atom` accepted `dim <= 0` without complaint. `math.ceil(dim / 16)` is `0` for any non-positive dim, so no SHA-256 blocks were generated and it returned a **length-0** float64 array.

Nothing downstream rejects that vector:

```
encode_atom("cat", 0)  -> shape (0,)
bind / unbind / bundle -> shape (0,)
byte round-trip        -> shape (0,)
similarity(a, b)       -> nan        <-- silently corrupts ranking
```

A `nan` similarity poisons scoring instead of surfacing the bad input, so the failure shows up far from its cause. `MemoryStore` passes a caller-supplied `hrr_dim` straight through, so `MemoryStore(hrr_dim=0)` reached this.

## Fix

Raise `ValueError` in `encode_atom`. It is the chokepoint for the computation — `encode_text` (both the tokenised branch *and* the empty-token branch) and `encode_fact` reach it for every `dim`.

**Also validate `hrr_dim` in `MemoryStore.__init__`.** Validating only in `encode_atom` would have introduced a worse failure than it fixed. `add_fact` commits the fact row *before* computing its vector, so:

```python
s = MemoryStore(hrr_dim=0)
s.add_fact("the cat sat")   # raises ValueError...
# ...but the row is already committed:
#   [(1, 'the cat sat', None)]     hrr_vector NULL
s.add_fact("the cat sat")   # returns 1 via dedup -- reports success,
#                             vector still NULL
```

Rejecting at construction fails before the database is opened, so that path is unreachable. Verified: no file is created for an invalid dim.

Non-integer `dim` needs no handling — it already fails loudly with `TypeError` from the list slice.

## Verification

- `281 passed` locally, 3.10–3.14 in CI.
- New tests fail against unfixed code (9 failures) and pass here.
- Covers `encode_atom`, `encode_text` (both branches), `encode_fact`, and `MemoryStore.__init__`, plus `dim=1` as the smallest valid value.

## Review

Reviewed adversarially by Codex and Antigravity.

- **Codex [high]** — the partial-write path above. Reproduced it directly and fixed by validating at construction. Codex re-reviewed and approved.
- **Codex [medium]** — legacy zero-byte vectors in existing databases bypass `encode_atom`. Declined as out of scope: no production caller passes a non-default `hrr_dim`, so no such data can exist. Codex accepted this on re-review.
- **Antigravity [high]** — claimed `encode_text`'s empty-token branch builds a vector without calling `encode_atom` and that one of the new tests fails. Rejected: the branch is `return encode_atom("__hrr_empty__", dim)`, and the named test passes. There is a test specifically covering that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm