### PR TITLE
perf(codebase): drop O(n^2) re-walk from get_function_signatures

### DIFF
--- a/src/ouroboros/codebase.py
+++ b/src/ouroboros/codebase.py
@@ -3,6 +3,7 @@
 import ast
 import logging
 import subprocess
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -152,29 +153,31 @@ def get_function_signatures(path: Path) -> List[Dict[str, Any]]:
 
     signatures = []
 
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            args = []
-            for arg in node.args.args:
-                args.append(arg.arg)
+    # Breadth-first, carrying the enclosing class down to each child. This
+    # mirrors ast.walk's traversal order while tracking the parent, so a
+    # function's owning class is known when it is reached instead of being
+    # rediscovered by re-walking the whole tree per function.
+    queue = deque([(tree, None)])
+    while queue:
+        node, owner = queue.popleft()
 
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             sig: Dict[str, Any] = {
                 "name": node.name,
-                "args": args,
+                "args": [arg.arg for arg in node.args.args],
                 "line": node.lineno,
                 "type": "function",
             }
-
-            # Check if this is a method (parent is a ClassDef)
-            for parent_node in ast.walk(tree):
-                if isinstance(parent_node, ast.ClassDef):
-                    for child in ast.iter_child_nodes(parent_node):
-                        if child is node:
-                            sig["type"] = "method"
-                            sig["class"] = parent_node.name
-                            break
-
+            # Only a direct child of a ClassDef body is a method: a function
+            # nested inside another function, or under an `if` in a class
+            # body, stays a plain function.
+            if owner is not None:
+                sig["type"] = "method"
+                sig["class"] = owner
             signatures.append(sig)
+
+        child_owner = node.name if isinstance(node, ast.ClassDef) else None
+        queue.extend((child, child_owner) for child in ast.iter_child_nodes(node))
 
     return signatures
 

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -86,6 +86,87 @@ def test_get_function_signatures(tmp_path):
     assert method_sig['line'] == 5
 
 
+def test_get_function_signatures_attributes_nested_class(tmp_path):
+    """A method belongs to its immediate class, not the outermost one."""
+    test_file = tmp_path / 'nested.py'
+    test_file.write_text(textwrap.dedent('''
+        class Outer:
+            class Inner:
+                def m(self):
+                    pass
+    ''').lstrip())
+
+    assert get_function_signatures(test_file) == [
+        {'name': 'm', 'args': ['self'], 'line': 3, 'type': 'method', 'class': 'Inner'},
+    ]
+
+
+def test_get_function_signatures_nested_function_is_not_a_method(tmp_path):
+    """Only a direct child of a class body is a method."""
+    test_file = tmp_path / 'inner.py'
+    test_file.write_text(textwrap.dedent('''
+        class C:
+            def m(self):
+                def helper():
+                    pass
+                return helper
+    ''').lstrip())
+
+    assert get_function_signatures(test_file) == [
+        {'name': 'm', 'args': ['self'], 'line': 2, 'type': 'method', 'class': 'C'},
+        {'name': 'helper', 'args': [], 'line': 3, 'type': 'function'},
+    ]
+
+
+def test_get_function_signatures_indirect_class_child_is_not_a_method(tmp_path):
+    """A def under an `if` in a class body is not a direct child of the class."""
+    test_file = tmp_path / 'guarded.py'
+    test_file.write_text(textwrap.dedent('''
+        import typing
+
+        class C:
+            if typing.TYPE_CHECKING:
+                def m(self):
+                    pass
+    ''').lstrip())
+
+    assert get_function_signatures(test_file) == [
+        {'name': 'm', 'args': ['self'], 'line': 5, 'type': 'function'},
+    ]
+
+
+def test_get_function_signatures_async_method(tmp_path):
+    test_file = tmp_path / 'async_mod.py'
+    test_file.write_text(textwrap.dedent('''
+        class C:
+            async def fetch(self, url):
+                pass
+    ''').lstrip())
+
+    assert get_function_signatures(test_file) == [
+        {'name': 'fetch', 'args': ['self', 'url'], 'line': 2,
+         'type': 'method', 'class': 'C'},
+    ]
+
+
+def test_get_function_signatures_preserves_breadth_first_order(tmp_path):
+    """Shallower definitions are reported before deeper ones."""
+    test_file = tmp_path / 'order.py'
+    test_file.write_text(textwrap.dedent('''
+        def first():
+            pass
+
+        class C:
+            def second(self):
+                def third():
+                    pass
+    ''').lstrip())
+
+    assert [s['name'] for s in get_function_signatures(test_file)] == [
+        'first', 'second', 'third',
+    ]
+
+
 def test_get_function_signatures_syntax_error(tmp_path):
     bad_file = tmp_path / 'bad.py'
     bad_file.write_text('def incomplete(')


### PR DESCRIPTION
Closes #42.

## Problem

For every function node found, the method check re-walked the **entire tree** looking for a `ClassDef` that had that node as a direct child:

```python
for node in ast.walk(tree):
    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
        ...
        for parent_node in ast.walk(tree):        # <-- full re-walk, per function
            if isinstance(parent_node, ast.ClassDef):
                for child in ast.iter_child_nodes(parent_node):
                    if child is node:
                        ...
                        break                      # <-- only leaves the innermost loop
```

With `f` functions and `n` nodes that is O(f·n). The `break` only left the innermost loop, so the scan continued over the remaining `ClassDef`s even after a match.

## Fix

Walk once, carrying the enclosing class down to each child so a function's owner is known when it is reached. The traversal is the same breadth-first deque walk `ast.walk` itself performs, so output order is unchanged.

## Behaviour is identical

This is a pure refactor. The details worth naming, all preserved:

- a method belongs to its **immediate** class, not the outermost one
- a function nested inside a method is a function, not a method
- a `def` under an `if` in a class body is not a direct child of the `ClassDef`, so it stays a function
- only `node.args.args` is collected, so positional-only, keyword-only and `**kwargs` are still omitted (pre-existing limitation, deliberately left alone)

**Verification:** ran both implementations over all 58 Python files in the repo — 641 signatures, **zero differences** — plus ten adversarial cases (nested and deeply-nested classes, async methods, decorated methods, `try`/`except` and comprehensions in class bodies, shadowed names).

The new tests characterise this behaviour and **pass against both the old and the new implementation**, which is the point: they lock in semantics that must not drift.

## Performance

| target | before | after | |
|---|---|---|---|
| all of `src/` (30 files) | 476 ms | 78 ms | **6.1x** |
| `moltbook.py` alone (1426 lines) | 115 ms | 12 ms | **9.3x** |

## Verification

- `286 passed` locally, 3.10–3.14 in CI.

## Review

Reviewed adversarially by Codex and Antigravity; both approve with no findings. Codex independently diffed old vs new across the repo (70,549 nodes, 646 signatures) and over adversarial decorators, walrus operators, lambdas, `match` cases, comprehensions and duplicate names, and confirmed the FIFO deque reproduces `ast.walk` order exactly including repeated node references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm