### PR TITLE
refactor(git_ops): own the porcelain path parsing instead of being patched

### DIFF
--- a/src/ouroboros/__init__.py
+++ b/src/ouroboros/__init__.py
@@ -101,43 +101,6 @@ def _patch_policy_decision_metrics() -> None:
     policies.validate_change_size = validate_change_size
 
 
-def _patch_git_ops_porcelain_parser() -> None:
-    """Keep git_ops path parsing fixed without editing that guarded module."""
-    from functools import wraps
-
-    from . import git_ops
-    from .backends import _git_porcelain_changes
-
-    @wraps(git_ops.commit_auto_state)
-    def commit_auto_state(repo):
-        porcelain = git_ops._git(repo, "status", "--porcelain", check=False).stdout
-        if not porcelain.strip():
-            return False
-
-        to_add = []
-        for _, path in _git_porcelain_changes(porcelain):
-            if any(
-                path.startswith(prefix) or path == prefix.rstrip("/")
-                for prefix in git_ops._AUTO_STATE_FILES
-            ):
-                to_add.append(path)
-
-        if not to_add:
-            return False
-
-        git_ops._git(repo, "add", *to_add)
-        staged = git_ops._git(repo, "diff", "--cached", "--name-only", check=False).stdout.strip()
-        if not staged:
-            return False
-
-        git_ops._git(repo, "commit", "-m", "chore: auto-commit state files before improvement cycle")
-        git_ops._git(repo, "push", "origin", git_ops.current_branch(repo), timeout=60)
-        git_ops.log.info("Auto-committed state files: %s", ", ".join(to_add))
-        return True
-
-    git_ops.commit_auto_state = commit_auto_state
-
-
 def _patch_improvement_path_allowed() -> None:
     """Keep improvement path checks aligned without editing the guarded module."""
     from functools import wraps
@@ -163,5 +126,4 @@ def _patch_improvement_path_allowed() -> None:
 
 
 _patch_policy_decision_metrics()
-_patch_git_ops_porcelain_parser()
 _patch_improvement_path_allowed()

--- a/src/ouroboros/backends.py
+++ b/src/ouroboros/backends.py
@@ -31,7 +31,13 @@ import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from .git_ops import (
+    _decode_git_path,
+    _git_porcelain_changes,
+    _git_porcelain_target_path,
+)
 
 log = logging.getLogger(__name__)
 
@@ -322,87 +328,6 @@ def _git(repo: Path, *args: str, timeout: int = 30) -> subprocess.CompletedProce
 def _untracked_files(repo: Path) -> set:
     proc = _git(repo, "ls-files", "--others", "--exclude-standard")
     return {_decode_git_path(line) for line in proc.stdout.splitlines() if line.strip()}
-
-
-_GIT_C_ESCAPES = {
-    "a": b"\a",
-    "b": b"\b",
-    "f": b"\f",
-    "n": b"\n",
-    "r": b"\r",
-    "t": b"\t",
-    "v": b"\v",
-    "\\": b"\\",
-    '"': b'"',
-}
-
-
-def _decode_git_path(path: str) -> str:
-    """Decode a C-quoted path from git output."""
-    path = path.strip()
-    if len(path) < 2 or path[0] != '"' or path[-1] != '"':
-        return path
-
-    raw = path[1:-1]
-    decoded = bytearray()
-    i = 0
-    while i < len(raw):
-        char = raw[i]
-        if char != "\\":
-            decoded.extend(char.encode("utf-8"))
-            i += 1
-            continue
-
-        i += 1
-        if i >= len(raw):
-            decoded.append(ord("\\"))
-            break
-
-        char = raw[i]
-        if char in "01234567":
-            octal = char
-            i += 1
-            while i < len(raw) and len(octal) < 3 and raw[i] in "01234567":
-                octal += raw[i]
-                i += 1
-            decoded.append(int(octal, 8))
-            continue
-
-        decoded.extend(_GIT_C_ESCAPES.get(char, char.encode("utf-8")))
-        i += 1
-
-    return decoded.decode("utf-8", "surrogateescape")
-
-
-def _git_porcelain_target_path(line: str) -> str:
-    """Return the changed path from a git status --porcelain line."""
-    status = line[:2]
-    path = line[3:].strip()
-    if "R" in status or "C" in status:
-        in_quote = False
-        escaped = False
-        for i, char in enumerate(path):
-            if escaped:
-                escaped = False
-                continue
-            if in_quote and char == "\\":
-                escaped = True
-                continue
-            if char == '"':
-                in_quote = not in_quote
-                continue
-            if not in_quote and path.startswith(" -> ", i):
-                path = path[i + 4:].strip()
-                break
-    return _decode_git_path(path)
-
-
-def _git_porcelain_changes(porcelain: str) -> Iterator[Tuple[str, str]]:
-    """Yield ``(status, decoded_path)`` entries from git status porcelain output."""
-    for line in porcelain.splitlines():
-        if not line.strip():
-            continue
-        yield line[:2], _git_porcelain_target_path(line)
 
 
 def _build_agent_prompt(task: Any, plan: str, config: Any) -> str:

--- a/src/ouroboros/git_ops.py
+++ b/src/ouroboros/git_ops.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Iterator, List, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +41,100 @@ def is_clean(repo: Path) -> bool:
     return result.stdout.strip() == ""
 
 
+_GIT_C_ESCAPES = {
+    "a": b"\a",
+    "b": b"\b",
+    "f": b"\f",
+    "n": b"\n",
+    "r": b"\r",
+    "t": b"\t",
+    "v": b"\v",
+    "\\": b"\\",
+    '"': b'"',
+}
+
+
+def _decode_git_path(path: str) -> str:
+    """Decode a C-quoted path from git output.
+
+    git quotes any path containing spaces, quotes, backslashes or non-ASCII
+    bytes, escaping the contents C-style (``\\303\\251`` for a UTF-8 e-acute).
+    Unquoted paths are returned unchanged.
+    """
+    path = path.strip()
+    if len(path) < 2 or path[0] != '"' or path[-1] != '"':
+        return path
+
+    raw = path[1:-1]
+    decoded = bytearray()
+    i = 0
+    while i < len(raw):
+        char = raw[i]
+        if char != "\\":
+            decoded.extend(char.encode("utf-8"))
+            i += 1
+            continue
+
+        i += 1
+        if i >= len(raw):
+            decoded.append(ord("\\"))
+            break
+
+        char = raw[i]
+        if char in "01234567":
+            octal = char
+            i += 1
+            while i < len(raw) and len(octal) < 3 and raw[i] in "01234567":
+                octal += raw[i]
+                i += 1
+            decoded.append(int(octal, 8))
+            continue
+
+        decoded.extend(_GIT_C_ESCAPES.get(char, char.encode("utf-8")))
+        i += 1
+
+    return decoded.decode("utf-8", "surrogateescape")
+
+
+def _git_porcelain_target_path(line: str) -> str:
+    """Return the changed path from a git status --porcelain line.
+
+    For renames and copies the line is ``XY <orig> -> <dest>``; the separator
+    is only meaningful outside a quoted path, since a filename may itself
+    contain " -> ".
+    """
+    status = line[:2]
+    path = line[3:].strip()
+    if "R" in status or "C" in status:
+        in_quote = False
+        escaped = False
+        for i, char in enumerate(path):
+            if escaped:
+                escaped = False
+                continue
+            if in_quote and char == "\\":
+                escaped = True
+                continue
+            if char == '"':
+                in_quote = not in_quote
+                continue
+            if not in_quote and path.startswith(" -> ", i):
+                path = path[i + 4:].strip()
+                break
+    return _decode_git_path(path)
+
+
+def _git_porcelain_changes(porcelain: str) -> Iterator[Tuple[str, str]]:
+    """Yield ``(status, decoded_path)`` entries from git status porcelain output."""
+    for line in porcelain.splitlines():
+        if not line.strip():
+            continue
+        yield line[:2], _git_porcelain_target_path(line)
+
+
 # Files that the main loop modifies during normal operation.
+# A trailing slash means "this directory and everything under it"; every other
+# entry names one exact file.
 _AUTO_STATE_FILES = [
     "config/state.json",
     "config/improvement_history.json",
@@ -50,6 +143,22 @@ _AUTO_STATE_FILES = [
     "config/metrics.json",
     "docs/wiki/",
 ]
+
+
+def _is_auto_state_path(path: str) -> bool:
+    """Return True if path is one of the files the loop may auto-commit.
+
+    Exact entries are compared for equality rather than by prefix: matching
+    "config/state.json" with startswith would also pull in a sibling like
+    config/state.json.backup, and commit_auto_state pushes what it stages.
+    """
+    for entry in _AUTO_STATE_FILES:
+        if entry.endswith("/"):
+            if path == entry.rstrip("/") or path.startswith(entry):
+                return True
+        elif path == entry:
+            return True
+    return False
 
 
 def commit_auto_state(repo: Path) -> bool:
@@ -61,12 +170,10 @@ def commit_auto_state(repo: Path) -> bool:
     if not porcelain.strip():
         return False
 
-    to_add: list[str] = []
-    for line in porcelain.splitlines():
-        # porcelain format: XY <path>  or  XY <orig> -> <path>
-        path = line[3:].split(" -> ")[-1]
-        if any(path.startswith(prefix) or path == prefix.rstrip("/") for prefix in _AUTO_STATE_FILES):
-            to_add.append(path)
+    to_add: list[str] = [
+        path for _status, path in _git_porcelain_changes(porcelain)
+        if _is_auto_state_path(path)
+    ]
 
     if not to_add:
         return False

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -2,9 +2,15 @@
 
 import time
 from unittest.mock import patch, MagicMock
+
+import pytest
 from pathlib import Path
 
 from ouroboros.git_ops import (
+    _decode_git_path,
+    _is_auto_state_path,
+    _git_porcelain_changes,
+    _git_porcelain_target_path,
     _safe_git_env,
     commit_auto_state,
     create_issue,
@@ -166,3 +172,132 @@ def test_find_open_issue_by_marker(mock_run):
     )
     url = find_open_issue_by_marker(Path("/tmp/repo"), "<!-- ouroboros:auto-issue:abc -->")
     assert url == "https://github.com/repo/issues/8"
+
+
+# -- C-quoted path decoding (migrated here from backends) --------------------
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("config/state.json", "config/state.json"),          # unquoted, unchanged
+        ('"config/state.json"', "config/state.json"),         # quoted, no escapes
+        ('"config/state with space.json"', "config/state with space.json"),
+        (r'"config/\303\274mlaut.json"', "config/ümlaut.json"),  # octal UTF-8
+        (r'"config/say \"hi\".json"', 'config/say "hi".json'),   # escaped quotes
+        (r'"config/back\\slash.json"', "config/back\\slash.json"),
+        (r'"config/tab\there.json"', "config/tab\there.json"),
+        ('"', '"'),                                           # too short to be quoted
+    ],
+)
+def test_decode_git_path(raw, expected):
+    assert _decode_git_path(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (" M config/state.json", "config/state.json"),
+        (' M "config/state with space.json"', "config/state with space.json"),
+        ("?? config/new.json", "config/new.json"),
+        ('R  old.json -> new.json', "new.json"),
+        # " -> " inside a quoted filename must not be treated as the separator
+        ('R  "a.json" -> "weird -> name.json"', "weird -> name.json"),
+        (' M "has -> arrow.json"', "has -> arrow.json"),
+    ],
+)
+def test_git_porcelain_target_path(line, expected):
+    assert _git_porcelain_target_path(line) == expected
+
+
+def test_git_porcelain_changes_skips_blank_lines():
+    porcelain = ' M config/state.json\n\n?? config/new.json\n'
+    assert list(_git_porcelain_changes(porcelain)) == [
+        (" M", "config/state.json"),
+        ("??", "config/new.json"),
+    ]
+
+
+@patch("ouroboros.git_ops.current_branch", return_value="main")
+@patch("ouroboros.git_ops._git")
+def test_commit_auto_state_stages_quoted_state_paths(mock_git, mock_branch):
+    """Quoted paths must be decoded before the prefix check and the git add.
+
+    Without decoding, the path still carries its surrounding quotes, fails
+    startswith("config/"), and the state file is silently never committed.
+    """
+    mock_git.side_effect = [
+        MagicMock(stdout=' M "docs/wiki/page with space.md"\n M config/metrics.json\n'),
+        MagicMock(),                                          # git add
+        MagicMock(stdout="docs/wiki/page with space.md\n"),   # diff --cached
+        MagicMock(),                                          # git commit
+        MagicMock(),                                          # git push
+    ]
+
+    assert commit_auto_state(Path("/tmp/repo")) is True
+
+    add_call = mock_git.call_args_list[1]
+    assert add_call.args[1] == "add"
+    assert add_call.args[2:] == ("docs/wiki/page with space.md", "config/metrics.json")
+
+
+@patch("ouroboros.git_ops.current_branch", return_value="main")
+@patch("ouroboros.git_ops._git")
+def test_commit_auto_state_decodes_octal_escaped_state_paths(mock_git, mock_branch):
+    mock_git.side_effect = [
+        MagicMock(stdout=' M "docs/wiki/\\303\\274mlaut.md"\n'),
+        MagicMock(),
+        MagicMock(stdout="docs/wiki/ümlaut.md\n"),
+        MagicMock(),
+        MagicMock(),
+    ]
+
+    assert commit_auto_state(Path("/tmp/repo")) is True
+    assert mock_git.call_args_list[1].args[2:] == ("docs/wiki/ümlaut.md",)
+
+
+def test_commit_auto_state_is_defined_in_git_ops():
+    """Regression guard: this logic belongs in git_ops, not a monkeypatch.
+
+    It previously lived in ouroboros/__init__.py, which rebound
+    git_ops.commit_auto_state at package-import time so the source here was
+    dead code.
+    """
+    import inspect
+
+    from ouroboros import backends, git_ops  # noqa: F401  (import triggers any patching)
+
+    assert inspect.getsourcefile(git_ops.commit_auto_state) == git_ops.__file__
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("config/state.json", True),
+        ("config/metrics.json", True),
+        ("docs/wiki", True),                  # the directory itself
+        ("docs/wiki/architecture.md", True),  # anything under it
+        ("docs/wiki/nested/deep.md", True),
+        # Exact entries must not match by prefix -- commit_auto_state pushes
+        # whatever it stages.
+        ("config/state.json.backup", False),
+        ("config/state.json.orig", False),
+        ("config/metrics.json.tmp", False),
+        ("config/other.json", False),
+        ("docs/wikipedia/page.md", False),
+        ("src/ouroboros/git_ops.py", False),
+    ],
+)
+def test_is_auto_state_path(path, expected):
+    assert _is_auto_state_path(path) is expected
+
+
+@patch("ouroboros.git_ops.current_branch", return_value="main")
+@patch("ouroboros.git_ops._git")
+def test_commit_auto_state_ignores_sibling_of_state_file(mock_git, mock_branch):
+    """config/state.json.backup must not be swept in by a prefix match."""
+    mock_git.side_effect = [
+        MagicMock(stdout=" M config/state.json.backup\n"),
+    ]
+
+    assert commit_auto_state(Path("/tmp/repo")) is False
+    assert mock_git.call_count == 1  # never reached git add


### PR DESCRIPTION
Closes #29.

## What was actually going on

The issue says `backends.py` monkeypatches `git_ops` at import time. That's the right diagnosis but the wrong location — it's `src/ouroboros/__init__.py`, and it patches **three** modules at package-import time. Its own docstrings say why:

```python
def _patch_git_ops_porcelain_parser() -> None:
    """Keep git_ops path parsing fixed without editing that guarded module."""
```

`git_ops.py`, `policies.py` and `improvement.py` are all listed in `SafetyConfig.forbidden_modification_paths`, so the fixes were written as import side effects instead. The observable result:

```python
>>> inspect.getsourcefile(git_ops.commit_auto_state)
'.../src/ouroboros/__init__.py'      # not git_ops.py
```

Reading `git_ops.py` told you nothing about what actually ran, and the code in it was dead.

## The bug the patch was hiding

`git_ops.commit_auto_state` split porcelain lines with `line[3:].split(" -> ")[-1]`. git C-quotes any path containing a space, quote, backslash or non-ASCII byte, so the quotes and octal escapes stay in the string and the path fails the `_AUTO_STATE_FILES` check:

```
 M "docs/wiki/page with space.md"
 M "docs/wiki/\303\274mlaut.md"
 M config/metrics.json

old -> ['config/metrics.json']
new -> ['docs/wiki/page with space.md', 'docs/wiki/ümlaut.md', 'config/metrics.json']
```

Two state files silently skipped — the worktree stays dirty and the next improvement cycle sees an unclean tree.

## Fix

- Move `_decode_git_path`, `_git_porcelain_target_path`, `_git_porcelain_changes` from `backends.py` into `git_ops.py`.
- `commit_auto_state` uses them; delete `_patch_git_ops_porcelain_parser`.
- `backends.py` imports the three names from `git_ops`, so `backends.<name>` still resolves for existing callers and tests.

This also points the dependency the right way round: `git_ops` no longer needs `backends`, and importing the package no longer drags `backends` in.

### Allowlist tightening (found in review)

Every `_AUTO_STATE_FILES` entry was matched with `startswith`, so `config/state.json.backup` passed as a state file — and `commit_auto_state` **pushes** whatever it stages. Decoding quoted paths *widens* that hole, since such a sibling previously failed the check on its leading quote and now would not. `_is_auto_state_path` now requires equality for the five exact files and keeps prefix matching only for the one directory entry, `docs/wiki/`.

## Verification

- `316 passed` locally, 3.10–3.14 in CI.
- `inspect.getsourcefile(git_ops.commit_auto_state)` now returns `git_ops.py`, asserted by a regression test so the monkeypatch can't come back.
- New tests cover C-quoted decoding (spaces, octal UTF-8, escaped quotes, backslashes, tabs), `" -> "` inside quoted rename targets, and the `config/state.json.backup` collision.

## Still outstanding

Two import-time patches remain in `__init__.py`, for `policies` and `improvement` — same pattern, same cause. Out of scope here; filed as #51.

The underlying tension is worth naming: the safety policy that forbids editing these files is being routed around by the agent it constrains, which is arguably worse than either editing them or leaving them alone.

## Review

Reviewed adversarially by Codex and Antigravity. Antigravity approved. Codex confirmed runtime equivalence with the removed patch and no import cycle, then flagged the `startswith` allowlist defect — fixed above, and Codex approved on re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm
