### PR TITLE
feat(policies): add AST-based import policy validation

### DIFF
--- a/src/ouroboros/config.py
+++ b/src/ouroboros/config.py
@@ -76,3 +76,25 @@ class SafetyConfig:
         "evaluation.py",
         "policies.py",
     )
+
+    # Modules generated code may not import, checked by
+    # policies.validate_import_policy. Matching covers submodules, so "socket"
+    # also rejects "import socket.foo" and "from socket import socket".
+    #
+    # This is a lint-level guard, not a capability boundary. subprocess, os and
+    # urllib stay importable because the codebase depends on them, so code that
+    # passes this check can still spawn processes and reach the network. It
+    # catches an improvement that casually reaches for pickle or ctypes; it does
+    # not contain one that is trying to get out. Enforce real limits in a
+    # sandbox.
+    #
+    # The default entries are unused anywhere in src/ or tests/, so it rejects
+    # nothing that exists today -- a test asserts that against the real tree.
+    forbidden_import_modules: Tuple[str, ...] = (
+        "ctypes",
+        "marshal",
+        "pickle",
+        "pty",
+        "shelve",
+        "socket",
+    )

--- a/src/ouroboros/policies.py
+++ b/src/ouroboros/policies.py
@@ -1,6 +1,7 @@
+import ast
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 
 from .config import SafetyConfig
 
@@ -49,6 +50,153 @@ def validate_modification_scope(
             violations.append(
                 f"Out of scope: {file_path} (must be under {config.allowed_modification_paths})"
             )
+
+    return violations
+
+
+def _imported_module_names(tree: ast.AST) -> List[Tuple[str, int]]:
+    """Return (dotted module name, line number) for every import in the tree.
+
+    A from-import contributes both the module it reads from and each candidate
+    submodule, because `from urllib import request` and `import urllib.request`
+    load the same thing and a dotted blocklist entry must catch both. The
+    submodule form over-reports when the name is an attribute rather than a
+    module, which only matters for dotted blocklist entries.
+
+    Relative imports are skipped: `from . import x` names a module inside this
+    package, not the top-level module `x`, so it cannot match the blocklist.
+    """
+    names: List[Tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend((alias.name, node.lineno) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                names.append((node.module, node.lineno))
+                names.extend(
+                    (f"{node.module}.{alias.name}", node.lineno)
+                    for alias in node.names
+                    if alias.name != "*"
+                )
+    return names
+
+
+# Primitives that load a module named at runtime, which no static check can
+# resolve. Flagged so the blocklist cannot be sidestepped by a one-line
+# rewrite; none of them is used anywhere in src/ today.
+_DYNAMIC_IMPORT_CALLS = ("__import__", "eval", "exec")
+_DYNAMIC_IMPORT_ATTRS = ("import_module",)
+
+
+_DYNAMIC_PRIMITIVES = _DYNAMIC_IMPORT_CALLS + _DYNAMIC_IMPORT_ATTRS
+
+# Modules that re-export a dynamic loader under a bindable name.
+_DYNAMIC_LOADER_SOURCES = ("importlib", "builtins")
+
+
+def _dynamic_loader_bindings(tree: ast.AST) -> set:
+    """Return local names bound to a dynamic loader by a from-import.
+
+    `from importlib import import_module` and `from builtins import
+    __import__ as load` both produce a plain call that no attribute check
+    would see.
+    """
+    bound = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 0:
+            if node.module and node.module.split(".")[0] in _DYNAMIC_LOADER_SOURCES:
+                bound.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name in _DYNAMIC_PRIMITIVES
+                )
+    return bound
+
+
+def _dynamic_import_calls(tree: ast.AST) -> List[Tuple[str, int]]:
+    """Return (call name, line number) for runtime-import / eval primitives.
+
+    Covers the bare name, an attribute access such as
+    ``importlib.import_module`` or ``builtins.__import__``, and any local name
+    a from-import bound to one of them. It does not chase a loader through an
+    arbitrary expression -- see validate_import_policy's docstring on why this
+    is a lint rather than a boundary.
+    """
+    bound = _dynamic_loader_bindings(tree)
+    found: List[Tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and (
+            func.id in _DYNAMIC_IMPORT_CALLS or func.id in bound
+        ):
+            found.append((func.id, node.lineno))
+        elif isinstance(func, ast.Attribute) and func.attr in _DYNAMIC_PRIMITIVES:
+            found.append((func.attr, node.lineno))
+    return found
+
+
+def _is_forbidden_import(module: str, forbidden: Tuple[str, ...]) -> Optional[str]:
+    """Return the blocklist entry that module matches, or None.
+
+    Matching is on dotted-path segments so "os" rejects "os.path" but "socket"
+    does not reject an unrelated "socketserver".
+    """
+    for entry in forbidden:
+        if module == entry or module.startswith(entry + "."):
+            return entry
+    return None
+
+
+def validate_import_policy(
+    file_path: str,
+    source: str,
+    config: SafetyConfig | None = None,
+) -> List[str]:
+    """Report imports of modules on SafetyConfig.forbidden_import_modules.
+
+    Returns a list of violation messages (empty = valid).
+
+    This is a lint-level guard, not a security boundary. It reads the source
+    statically, so it constrains what generated code is *written* to do, not
+    what a determined program *can* do: subprocess, os and urllib all remain
+    importable, and a module name assembled at runtime is unknowable here.
+    Runtime-import and eval primitives are reported for that reason -- it
+    raises the cost of an accidental or casual bypass -- but real capability
+    limits belong in a sandbox, not in this function.
+
+    Source that does not parse is itself a violation: unparseable code cannot
+    be reviewed, and the caller is about to write it to disk.
+    """
+    config = config or SafetyConfig()
+    if not config.forbidden_import_modules:
+        return []
+
+    try:
+        tree = ast.parse(source, filename=file_path)
+    except SyntaxError as e:
+        return [f"Unparseable: {file_path} (line {e.lineno}: {e.msg})"]
+    except (ValueError, RecursionError) as e:
+        # e.g. embedded NUL on some versions, or pathological nesting.
+        return [f"Unparseable: {file_path} ({type(e).__name__}: {e})"]
+
+    violations = []
+    seen = set()
+    for module, lineno in _imported_module_names(tree):
+        entry = _is_forbidden_import(module, config.forbidden_import_modules)
+        if entry is not None and (lineno, entry) not in seen:
+            seen.add((lineno, entry))
+            violations.append(
+                f"Forbidden import: {file_path}:{lineno} imports {module} "
+                f"({entry} is not permitted)"
+            )
+
+    for name, lineno in _dynamic_import_calls(tree):
+        violations.append(
+            f"Dynamic import: {file_path}:{lineno} calls {name} "
+            f"(runtime module loading defeats import policy)"
+        )
 
     return violations
 

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,11 +1,14 @@
 """Tests for policies module."""
 
+import pytest
+
 from ouroboros.config import SafetyConfig
 from ouroboros.policies import (
     PolicyError,
     require_pr_only,
-    validate_modification_scope,
     validate_change_size,
+    validate_import_policy,
+    validate_modification_scope,
 )
 
 
@@ -103,3 +106,215 @@ def test_config_defaults_are_safe():
     assert config.max_lines_changed_per_pr == 200
     assert "config.py" in config.forbidden_modification_paths
     assert "improvement.py" in config.forbidden_modification_paths
+
+
+# -- validate_import_policy --------------------------------------------------
+
+def test_validate_import_policy_allows_clean_source():
+    source = "import json\nimport os.path\nfrom pathlib import Path\n"
+    assert validate_import_policy("src/ouroboros/x.py", source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import ctypes\n",
+        "import pickle\n",
+        "import socket\n",
+        "import marshal\n",
+        "import shelve\n",
+        "import pty\n",
+    ],
+)
+def test_validate_import_policy_rejects_each_default_module(source):
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    assert len(violations) == 1
+    assert "Forbidden import" in violations[0]
+
+
+@pytest.mark.parametrize(
+    ("source", "module"),
+    [
+        ("import pickle\n", "pickle"),
+        ("import pickle as p\n", "pickle"),
+        ("import socket.foo\n", "socket.foo"),          # submodule of a blocked root
+        ("from pickle import loads\n", "pickle"),
+        ("from socket import socket\n", "socket"),
+        ("from ctypes.util import find_library\n", "ctypes.util"),
+    ],
+)
+def test_validate_import_policy_catches_every_import_form(source, module):
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    assert len(violations) == 1
+    assert module in violations[0]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import socketserver\n",       # not a submodule of "socket"
+        "import pickletools\n",        # shares a prefix but is a distinct module
+        "from socketserver import TCPServer\n",
+    ],
+)
+def test_validate_import_policy_does_not_match_on_bare_prefix(source):
+    assert validate_import_policy("src/ouroboros/x.py", source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from . import pickle\n",
+        "from .. import socket\n",
+        "from .pickle import loads\n",
+    ],
+)
+def test_validate_import_policy_ignores_relative_imports(source):
+    """`from . import pickle` names a package-local module, not stdlib pickle."""
+    assert validate_import_policy("src/ouroboros/x.py", source) == []
+
+
+def test_validate_import_policy_reports_line_numbers():
+    source = "import json\n\nimport pickle\n"
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    assert violations == [
+        "Forbidden import: src/ouroboros/x.py:3 imports pickle "
+        "(pickle is not permitted)"
+    ]
+
+
+def test_validate_import_policy_reports_every_violation():
+    source = "import pickle\nimport socket\nimport json\n"
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    assert len(violations) == 2
+
+
+def test_validate_import_policy_finds_nested_imports():
+    """An import inside a function body is still an import."""
+    source = "def f():\n    import pickle\n    return pickle\n"
+    assert len(validate_import_policy("src/ouroboros/x.py", source)) == 1
+
+
+def test_validate_import_policy_flags_unparseable_source():
+    violations = validate_import_policy("src/ouroboros/x.py", "def broken(\n")
+    assert len(violations) == 1
+    assert "Unparseable" in violations[0]
+
+
+def test_validate_import_policy_respects_custom_config():
+    config = SafetyConfig(forbidden_import_modules=("json",))
+    assert validate_import_policy("x.py", "import pickle\n", config) == []
+    assert len(validate_import_policy("x.py", "import json\n", config)) == 1
+
+
+def test_validate_import_policy_empty_blocklist_allows_everything():
+    config = SafetyConfig(forbidden_import_modules=())
+    assert validate_import_policy("x.py", "import pickle\nimport ctypes\n", config) == []
+
+
+def test_validate_import_policy_empty_blocklist_skips_syntax_check():
+    """With nothing to enforce there is no reason to parse at all."""
+    config = SafetyConfig(forbidden_import_modules=())
+    assert validate_import_policy("x.py", "def broken(\n", config) == []
+
+
+def test_default_forbidden_imports_do_not_flag_the_existing_codebase():
+    """The shipped blocklist must not reject code that is already in the repo."""
+    from pathlib import Path as _Path
+
+    repo_root = _Path(__file__).resolve().parent.parent
+    offenders = []
+    for path in sorted((repo_root / "src").rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        offenders.extend(validate_import_policy(str(path), source))
+    assert offenders == []
+
+
+@pytest.mark.parametrize(
+    ("source", "call"),
+    [
+        ('__import__("pickle")\n', "__import__"),
+        ('import importlib\nimportlib.import_module("pickle")\n', "import_module"),
+        ('exec("import pickle")\n', "exec"),
+        ("eval(\"__import__('socket')\")\n", "eval"),
+    ],
+)
+def test_validate_import_policy_flags_dynamic_import_primitives(source, call):
+    """A blocklist is worthless if one line of indirection sidesteps it."""
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    assert any("Dynamic import" in v and call in v for v in violations)
+
+
+def test_validate_import_policy_dotted_entry_catches_both_import_forms():
+    """`from urllib import request` loads the same module as `import urllib.request`."""
+    config = SafetyConfig(forbidden_import_modules=("urllib.request",))
+
+    assert len(validate_import_policy("x.py", "import urllib.request\n", config)) == 1
+    assert len(validate_import_policy("x.py", "from urllib import request\n", config)) == 1
+    # The parent package on its own is still allowed.
+    assert validate_import_policy("x.py", "import urllib\n", config) == []
+
+
+def test_validate_import_policy_does_not_double_report_one_statement():
+    """from-import expansion must not turn one bad line into two violations."""
+    violations = validate_import_policy("x.py", "from pickle import loads, dumps\n")
+    assert len(violations) == 1
+
+
+def test_validate_import_policy_star_import():
+    assert len(validate_import_policy("x.py", "from pickle import *\n")) == 1
+
+
+def test_validate_import_policy_handles_null_bytes():
+    violations = validate_import_policy("x.py", "import json\x00\n")
+    assert len(violations) == 1
+    assert "Unparseable" in violations[0]
+
+
+def test_default_forbidden_imports_do_not_flag_the_test_suite():
+    """The blocklist must not reject the repo's own tests either."""
+    from pathlib import Path as _Path
+
+    repo_root = _Path(__file__).resolve().parent.parent
+    offenders = []
+    for path in sorted((repo_root / "tests").rglob("*.py")):
+        offenders.extend(
+            validate_import_policy(str(path), path.read_text(encoding="utf-8"))
+        )
+    assert offenders == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from importlib import import_module\nimport_module('pickle')\n",
+        "from importlib import import_module as load\nload('pickle')\n",
+        "from importlib.util import module_from_spec\n",  # binding form, no call
+    ],
+)
+def test_validate_import_policy_tracks_import_module_bindings(source):
+    """`from importlib import import_module` is ordinary style, not a trick."""
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    if "(" in source.split("\n", 1)[1]:
+        assert any("Dynamic import" in v for v in violations)
+
+
+def test_validate_import_policy_does_not_flag_unrelated_same_named_call():
+    """A local helper that merely shares a builtin's name is not a call to it."""
+    source = "def render(template):\n    return template\n\nrender('x')\n"
+    assert validate_import_policy("src/ouroboros/x.py", source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import builtins\nbuiltins.__import__('pickle')\n",
+        "import builtins\nbuiltins.eval('1')\n",
+        "import builtins\nbuiltins.exec('import pickle')\n",
+        "from builtins import __import__ as load\nload('pickle')\n",
+        "from builtins import __import__\n__import__('pickle')\n",
+    ],
+)
+def test_validate_import_policy_flags_builtins_qualified_loaders(source):
+    violations = validate_import_policy("src/ouroboros/x.py", source)
+    assert any("Dynamic import" in v for v in violations), source


### PR DESCRIPTION
Closes #43.

## What

`policies.py` validated *where* a change may write and *how large* it may be, but nothing looked at what generated code pulls in. `validate_import_policy` parses the source and reports imports of modules on the new `SafetyConfig.forbidden_import_modules`.

Handles every static form — plain, aliased, submodule, from-import, star-import, and imports nested inside function bodies.

## ⚠️ This is lint, not a sandbox

Stating this up front because it shaped the whole design. The function is documented as a lint-level guard:

> subprocess, os and urllib stay importable because the codebase depends on them, so code that passes can still spawn processes and reach the network. It catches an improvement that casually reaches for pickle or ctypes; it does not contain one that is trying to get out. Real capability limits belong in a sandbox.

`SafetyConfig.sandbox_enabled` already exists and defaults to `False`. This PR does not change that.

Because a denylist is trivially defeated by indirection, runtime-import and eval primitives are reported as well. Every form below is caught:

| form | caught |
|---|---|
| `__import__("pickle")` / `eval` / `exec` | ✅ |
| `importlib.import_module("pickle")` | ✅ |
| `from importlib import import_module` → `import_module(...)` | ✅ |
| `from importlib import import_module as load` → `load(...)` | ✅ |
| `builtins.__import__(...)` / `builtins.eval(...)` | ✅ |
| `from builtins import __import__ as load` → `load(...)` | ✅ |

A loader reached through an arbitrary expression (`getattr(builtins, name)`, a runtime-assembled string) is deliberately **not** chased — that is past what a static check can promise, and the docstring says so rather than implying coverage it doesn't have.

## Matching details

- Dotted-segment matching: `socket` rejects `socket` and `socket.foo`, but not `socketserver`; `pickle` does not reject `pickletools`.
- A from-import contributes both its module and each candidate submodule, so a dotted entry like `urllib.request` catches `from urllib import request` as well as `import urllib.request`. Deduplicated per line, so `from pickle import loads, dumps` is one violation.
- Relative imports are skipped — `from . import pickle` names a package-local module, not stdlib `pickle`.
- Unparseable source is itself a violation (`SyntaxError`, `ValueError`, `RecursionError`): it cannot be reviewed and the caller is about to write it to disk.

## Default blocklist

`ctypes`, `marshal`, `pickle`, `pty`, `shelve`, `socket`. None is imported anywhere in `src/` or `tests/`, so it rejects nothing that exists today — asserted by two tests that run the validator over the real tree, so the claim can't silently rot. `subprocess` and `urllib` are deliberately absent.

## Not wired in

**The setting has no runtime effect yet.** The natural call site is `improvement._validate_changes`, and `improvement.py` is both in `forbidden_modification_paths` and monkeypatched from `__init__.py`. Wiring it is entangled with that governance question, so it's tracked separately in #52 (informed by #51) rather than smuggled in here.

## Verification

`361 passed` locally, 3.10–3.14 in CI. 30 new tests.

## Review

Reviewed adversarially by Codex and Antigravity over four rounds; they drove most of the above:

- Both flagged the dynamic-import bypass — added primitive detection.
- Codex flagged the dotted from-import false negative and that the original config comment over-claimed safety — fixed and reworded.
- Codex then found `from importlib import import_module` unbound, then `builtins.__import__` — both closed.
- Codex held that the feature is unenforced; correct, and now stated prominently rather than buried, with #52 filed.
- Antigravity's LOW on `ast.parse` raising `ValueError` didn't reproduce on 3.14 (null bytes give `SyntaxError`), but it's handled defensively since CI spans five versions.
- **Rejected:** Antigravity's claim that `import ctypes` grants access to `ctypes.util`. Verified it raises `AttributeError` — submodules are not auto-imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm