### PR TITLE
feat(retry): retry transient API failures with exponential backoff

### DIFF
--- a/src/ouroboros/backends.py
+++ b/src/ouroboros/backends.py
@@ -323,7 +323,11 @@ def make_backend_client(
 
             # Compatible gateways still expect some bearer token; "ollama" is
             # what a local Ollama accepts and is harmless elsewhere.
-            return OpenAI(api_key=api_key or "ollama", base_url=base_url)
+            # max_retries=0 for the same reason as llm.make_client: retry.py owns
+            # retrying, and the SDK default of 2 would compound with it.
+            return OpenAI(
+                api_key=api_key or "ollama", base_url=base_url, max_retries=0
+            )
         except Exception:
             log.warning(
                 "OpenAI-compatible endpoint '%s' unavailable; falling back to the default client",

--- a/src/ouroboros/improvement.py
+++ b/src/ouroboros/improvement.py
@@ -795,7 +795,8 @@ def run_improvement_cycle(
         _MAX_REACT_ROUNDS = 5
         for react_round in range(1, _MAX_REACT_ROUNDS + 1):
             log.info("[improve] ReAct round %d/%d", react_round, _MAX_REACT_ROUNDS)
-            resp = identify_client.chat.completions.create(
+            resp = llm.create_completion(
+                identify_client,
                 model=model,
                 messages=messages,
                 response_format={"type": "json_object"}
@@ -824,7 +825,8 @@ def run_improvement_cycle(
             if react_round == _MAX_REACT_ROUNDS:
                 log.info("[improve] ReAct loop hit max rounds (%d), forcing final answer", _MAX_REACT_ROUNDS)
                 # Force a final answer without tools
-                resp = identify_client.chat.completions.create(
+                resp = llm.create_completion(
+                identify_client,
                     model=model,
                     messages=messages,
                     response_format={"type": "json_object"}

--- a/src/ouroboros/lifecycle.py
+++ b/src/ouroboros/lifecycle.py
@@ -1,0 +1,24 @@
+"""Process-wide shutdown signal.
+
+Lives in its own module so anything that waits -- the main loop's sleeps, the
+retry backoff in llm and moltbook -- can observe the same event without those
+modules importing each other.
+"""
+
+import threading
+
+shutdown_event = threading.Event()
+
+
+def is_shutting_down() -> bool:
+    """Return True once a graceful shutdown has been requested."""
+    return shutdown_event.is_set()
+
+
+def request_shutdown() -> None:
+    shutdown_event.set()
+
+
+def reset() -> None:
+    """Clear the flag. For tests; the runner sets it once and exits."""
+    shutdown_event.clear()

--- a/src/ouroboros/llm.py
+++ b/src/ouroboros/llm.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from openai import OpenAI
 
 from .model_defaults import DEFAULT_OPENAI_MODEL
+from . import lifecycle
+from .retry import is_retryable, retry_with_backoff
 from . import prompts
 
 log = logging.getLogger(__name__)
@@ -38,8 +40,32 @@ def load_openai_key() -> str:
 
 
 def make_client(api_key: str) -> Any:
-    """Create a reusable OpenAI client instance."""
-    return OpenAI(api_key=api_key)
+    """Create a reusable OpenAI client instance.
+
+    max_retries=0 because retry.retry_with_backoff owns retrying. The SDK
+    defaults to 2 internal retries, which would compound with our attempts --
+    4 x 3 = up to 12 transmissions for one logical call, and an outer backoff
+    that cannot see the inner ones.
+    """
+    return OpenAI(api_key=api_key, max_retries=0)
+
+
+@retry_with_backoff(cancelled=lifecycle.is_shutting_down)
+def create_completion(client: Any, **kwargs: Any) -> Any:
+    """Single chokepoint for chat completions, so every call gets retries.
+
+    Every completion in the codebase must go through here -- a test asserts
+    no module calls client.chat.completions.create directly.
+
+    Transient faults (429, 5xx, dropped connections, timeouts) are retried with
+    exponential backoff and jitter; everything else propagates on the first
+    attempt. See retry.is_retryable.
+    """
+    return client.chat.completions.create(**kwargs)
+
+
+# Backwards-compatible private alias.
+_create_completion = create_completion
 
 
 def _completion_token_kwargs(model: str, max_tokens: int) -> dict:
@@ -70,7 +96,7 @@ def chat_completion(
         }
         if response_format:
             kwargs["response_format"] = response_format
-        resp = client.chat.completions.create(**kwargs)
+        resp = create_completion(client, **kwargs)
         usage = None
         if resp.usage:
             usage = {
@@ -115,7 +141,8 @@ def identify_improvements(
     user_prompt = f"## Summary\n{summary}\n\n## Tests\n{test_results}\n\n## History\n{history}\n\n{additional_context}"
 
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
@@ -144,6 +171,13 @@ def identify_improvements(
             }
         return data, None
     except Exception as e:
+        # The fallback reshapes the request, so it can recover a capability or
+        # parsing failure. It cannot recover a transport outage -- create_completion
+        # has already spent its four attempts on that, and retrying here would
+        # spend four more for one logical operation.
+        if is_retryable(e):
+            log.warning("identify_improvements: call failed after retries (%s)", e)
+            return None, str(e)
         log.warning("identify_improvements: primary call failed (%s), retrying as plain JSON", e)
         content, usage = chat_completion(client, system_prompt, user_prompt + "\nOutput JSON.", model)
         try:
@@ -252,7 +286,8 @@ def generate_question_post(
 ) -> Optional[dict]:
     code_block = "\n\n".join(f"### {path}\n```python\n{content}\n```" for path, content in code_context.items())
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             response_format={"type": "json_object"},
             **_completion_token_kwargs(model, 600),
@@ -277,7 +312,8 @@ def analyze_code_suggestions(
     code_block = "\n\n".join(f"### {path}\n```python\n{content}\n```" for path, content in code_context.items())
     comments_text = "\n\n".join(f"Comment by {c.get('author', {}).get('name')}: {c.get('content')}" for c in comments)
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             response_format={"type": "json_object"},
             **_completion_token_kwargs(model, 800),
@@ -302,7 +338,8 @@ def generate_code_from_suggestion(
 ) -> Optional[list]:
     file_contents = "\n\n".join(f"### {path}\n```python\n{content}\n```" for path, content in code_context.items())
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             response_format={"type": "json_object"},
             **_completion_token_kwargs(model, 2000),
@@ -326,7 +363,8 @@ def analyze_comments_for_upgrades(
 ) -> Optional[dict]:
     comments_text = "\n\n".join([f"Comment by {c.get('author', {}).get('name')}: {c.get('content')}" for c in comments])
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             response_format={"type": "json_object"},
             **_completion_token_kwargs(model, 600),
@@ -349,7 +387,8 @@ def mine_insight_for_codebase(
     model: str = DEFAULT_OPENAI_MODEL,
 ) -> Optional[str]:
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             **_completion_token_kwargs(model, 150),
             messages=[
@@ -373,7 +412,8 @@ def extract_topic_signal(
 ) -> Optional[str]:
     replies_text = "\n".join([f"- {r.get('content') if isinstance(r, dict) else r}" for r in replies])
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             **_completion_token_kwargs(model, 80),
             messages=[
@@ -394,7 +434,8 @@ def extract_insights_batch(
 ) -> Optional[list]:
     posts_text = "\n\n".join([f"[{i}] {p.get('title')}: {p.get('content')}" for i, p in enumerate(posts[:5])])
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             response_format={"type": "json_object"},
             **_completion_token_kwargs(model, 300),
@@ -417,7 +458,8 @@ def generate_kb_summary(
 ) -> Optional[str]:
     entries_text = "\n".join([f"- {e.get('insight')}" for e in entries])
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             **_completion_token_kwargs(model, 200),
             messages=[
@@ -438,7 +480,8 @@ def pick_oddities(
 ) -> Optional[str]:
     posts_text = "\n\n".join([f"[{i}] {p.get('title')}: {p.get('content')[:200]}" for i, p in enumerate(posts[:20])])
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             **_completion_token_kwargs(model, 400),
             messages=[
@@ -478,7 +521,8 @@ def generate_post(
         if extra_context:
             user_msg += f"\n\n## Additional Live Metrics\n{extra_context}"
             
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             response_format={"type": "json_object"},
             **_completion_token_kwargs(model, 800),
@@ -496,7 +540,8 @@ def generate_post(
 def generate_comment(client: Any, post_title: str, post_content: str, model: str = DEFAULT_OPENAI_MODEL, codebase_context: str = "") -> Optional[str]:
     user_msg = f"Post title: {post_title}\n\nPost content: {post_content}\n\nContext: {codebase_context}"
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             messages=[{"role": "system", "content": prompts.load_comment_system_prompt()}, {"role": "user", "content": user_msg}],
             **_completion_token_kwargs(model, 300),
@@ -510,7 +555,8 @@ def generate_comment(client: Any, post_title: str, post_content: str, model: str
 def answer_question(client: Any, question: str, codebase_summary: str = "", model: str = DEFAULT_OPENAI_MODEL) -> Optional[str]:
     user_content = f"## Codebase\n{codebase_summary}\n\n## Question\n{question}"
     try:
-        resp = client.chat.completions.create(
+        resp = create_completion(
+            client,
             model=model,
             messages=[{"role": "system", "content": "You are a self-reflective agent."}, {"role": "user", "content": user_content}],
             **_completion_token_kwargs(model, 300),

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from . import lifecycle
 from .model_defaults import DEFAULT_OPENAI_MODEL
+from .retry import is_idempotent_request, retry_with_backoff
 from .storage import load_json_file, save_json_file
 
 log = logging.getLogger(__name__)
@@ -18,7 +20,9 @@ log = logging.getLogger(__name__)
 API_BASE = "https://www.moltbook.com/api/v1"
 WEB_BASE = "https://www.moltbook.com"
 
-_shutdown_event = threading.Event()
+# Aliased to the shared lifecycle event so llm's retry backoff observes the
+# same shutdown. Existing references to _shutdown_event keep working.
+_shutdown_event = lifecycle.shutdown_event
 
 MAX_SELF_QUESTION_LOG = 200
 MAX_BACKOFF_SECONDS = 900  # 15 min cap
@@ -66,6 +70,31 @@ def load_credentials(*, require_agent_name: bool = True) -> Credentials:
     return Credentials(api_key=api_key, agent_name=agent_name or "")
 
 
+def _send(req: "urllib.request.Request") -> Dict[str, Any]:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+_send_with_retry = retry_with_backoff(cancelled=lifecycle.is_shutting_down)(_send)
+
+
+def _urlopen_json(req: "urllib.request.Request") -> Dict[str, Any]:
+    """Send req and decode the JSON body.
+
+    Transient failures are retried only for idempotent methods. A POST that
+    the server committed but whose response was lost is indistinguishable
+    here from one it never received, and this API creates public posts and
+    comments -- replaying one would duplicate it. There is no idempotency key
+    to make that safe, so writes get a single attempt.
+
+    Retries live at this level rather than in _request so the MoltbookError
+    wrapper does not hide the original exception type from is_retryable.
+    """
+    if is_idempotent_request(req):
+        return _send_with_retry(req)
+    return _send(req)
+
+
 def _request(method: str, path: str, api_key: str, body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     url = f"{API_BASE}{path}"
     data = None
@@ -76,9 +105,7 @@ def _request(method: str, path: str, api_key: str, body: Optional[Dict[str, Any]
 
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            payload = resp.read().decode("utf-8")
-            return json.loads(payload)
+        return _urlopen_json(req)
     except Exception as exc:  # pragma: no cover - network errors
         raise MoltbookError(f"Request failed: {exc}") from exc
 

--- a/src/ouroboros/retry.py
+++ b/src/ouroboros/retry.py
@@ -1,0 +1,221 @@
+"""Retry with exponential backoff and jitter for external API calls.
+
+The agent runs unattended on a Raspberry Pi, so a rate limit or a dropped
+connection should cost a short wait rather than a skipped cycle.
+
+Two things this module is careful about:
+
+* Only transient failures are retried. A 400 or a 401 fails identically on
+  every attempt, so retrying one delays the error and burns quota.
+* Retrying is only safe for idempotent work. Replaying a POST that the server
+  already committed but whose response was lost creates a duplicate, so
+  callers opt in per request rather than getting retries by default.
+"""
+
+import functools
+import http.client
+import logging
+import random
+import ssl
+import time
+from typing import Any, Callable, Optional, Tuple, Type
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_ATTEMPTS = 4
+DEFAULT_BASE_DELAY = 1.0
+DEFAULT_MAX_DELAY = 30.0
+
+# HTTP statuses worth another attempt: rate limiting, request timeout, and
+# server-side faults including the Cloudflare 52x range.
+#
+# 409 is deliberately absent -- a conflict is a deterministic statement about
+# state, and replaying the same request reproduces it. 507 and 508 are absent
+# for the same reason: out of storage and loop detected do not clear on their
+# own.
+RETRYABLE_STATUS_CODES = frozenset(
+    {408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524}
+)
+
+# Mid-stream failures: the connection was accepted, then died. urllib surfaces
+# these without wrapping them in URLError, and none subclass ConnectionError.
+RETRYABLE_HTTP_EXCEPTIONS: Tuple[Type[BaseException], ...] = (
+    http.client.IncompleteRead,
+    http.client.BadStatusLine,      # RemoteDisconnected subclasses this
+    http.client.LineTooLong,
+    http.client.ResponseNotReady,
+)
+
+# HTTP methods safe to replay. Everything else may have taken effect before the
+# response was lost.
+IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE"})
+
+
+def _openai_retryable_types() -> Tuple[Type[BaseException], ...]:
+    """Return the openai exception classes that represent transient faults.
+
+    Imported lazily and defensively: the SDK is an optional dependency at
+    runtime for CLI-backend deployments, and its exception surface has moved
+    between major versions.
+    """
+    try:
+        import openai
+    except Exception:  # pragma: no cover - openai always present in tests
+        return ()
+
+    names = (
+        "RateLimitError",
+        "APIConnectionError",
+        "APITimeoutError",
+        "InternalServerError",
+    )
+    return tuple(
+        cls
+        for cls in (getattr(openai, name, None) for name in names)
+        if isinstance(cls, type) and issubclass(cls, BaseException)
+    )
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """Return True if exc looks transient and another attempt may succeed."""
+    # A TLS failure is a configuration or trust problem, not a blip. Checked
+    # first because URLError wraps it and would otherwise let it through.
+    if isinstance(exc, ssl.SSLError) and not isinstance(exc, ssl.SSLWantReadError):
+        return False
+
+    if isinstance(exc, RETRYABLE_HTTP_EXCEPTIONS):
+        return True
+
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+
+    retryable_types = _openai_retryable_types()
+    if retryable_types and isinstance(exc, retryable_types):
+        return True
+
+    # urllib raises HTTPError (a subclass of URLError) carrying a .code.
+    code = getattr(exc, "code", None)
+    if isinstance(code, int):
+        return code in RETRYABLE_STATUS_CODES
+
+    # openai APIStatusError and similar expose the status this way instead.
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status in RETRYABLE_STATUS_CODES
+
+    try:
+        from urllib.error import URLError
+
+        if isinstance(exc, URLError):
+            # Plain URLError means no response at all. Unwrap the reason so a
+            # permanent cause (bad certificate, unknown host) is not retried.
+            reason = getattr(exc, "reason", None)
+            if isinstance(reason, ssl.SSLError):
+                return False
+            return True
+    except Exception:  # pragma: no cover - stdlib always importable
+        pass
+
+    return False
+
+
+def is_idempotent_request(req: Any) -> bool:
+    """Return True if req may be safely replayed.
+
+    Accepts a urllib Request, or anything exposing get_method()/method.
+    Unknown shapes are treated as unsafe: the cost of a missed retry is a
+    skipped cycle, the cost of a wrong one is a duplicate public post.
+    """
+    method = None
+    getter = getattr(req, "get_method", None)
+    if callable(getter):
+        try:
+            method = getter()
+        except Exception:
+            method = None
+    if method is None:
+        method = getattr(req, "method", None)
+    if not isinstance(method, str):
+        return False
+    return method.upper() in IDEMPOTENT_METHODS
+
+
+def backoff_delay(
+    attempt: int,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    rng: Optional[Callable[[float, float], float]] = None,
+) -> float:
+    """Return the delay before ``attempt`` (1-based), using full jitter.
+
+    Full jitter -- uniform over [0, capped exponential] -- rather than
+    exponential plus a small random term. Several agents retrying a shared
+    rate limit in lockstep is the failure this avoids.
+    """
+    uniform = rng or random.uniform
+    ceiling = min(max_delay, base_delay * (2 ** max(0, attempt - 1)))
+    return uniform(0.0, ceiling)
+
+
+def retry_with_backoff(
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    retryable: Callable[[BaseException], bool] = is_retryable,
+    sleep: Optional[Callable[[float], None]] = None,
+    cancelled: Optional[Callable[[], bool]] = None,
+) -> Callable:
+    """Retry the wrapped callable on transient failures.
+
+    Non-retryable exceptions propagate immediately, and the last attempt's
+    exception propagates rather than being swallowed -- callers already handle
+    failure, and hiding it would turn an outage into silently missing data.
+
+    ``cancelled`` is polled before each wait and before each further attempt.
+    Without it a service outage would hold the process in backoff across four
+    attempts, delaying SIGTERM by up to the sum of the timeouts and waits and
+    risking writes issued after shutdown was requested.
+
+    ``sleep`` defaults to ``time.sleep`` resolved at call time, not at
+    decoration time. Binding it as a default argument would capture the
+    function when the module is imported, so a decorated call site could never
+    be tested without waiting out the real backoff.
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            pause = sleep if sleep is not None else time.sleep
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return fn(*args, **kwargs)
+                except Exception as exc:
+                    if attempt >= max_attempts or not retryable(exc):
+                        raise
+                    if cancelled is not None and cancelled():
+                        log.info(
+                            "%s failed and shutdown was requested -- not retrying",
+                            getattr(fn, "__name__", "call"),
+                        )
+                        raise
+                    delay = backoff_delay(attempt, base_delay, max_delay)
+                    log.warning(
+                        "%s failed (attempt %d/%d): %s -- retrying in %.1fs",
+                        getattr(fn, "__name__", "call"),
+                        attempt,
+                        max_attempts,
+                        exc,
+                        delay,
+                    )
+                    pause(delay)
+                    if cancelled is not None and cancelled():
+                        log.info(
+                            "shutdown requested during backoff -- abandoning %s",
+                            getattr(fn, "__name__", "call"),
+                        )
+                        raise
+            raise AssertionError("unreachable")  # pragma: no cover
+
+        return wrapper
+
+    return decorator

--- a/src/ouroboros/self_improve.py
+++ b/src/ouroboros/self_improve.py
@@ -136,7 +136,8 @@ def run_self_improve(client: Any, state: Dict[str, Any], model: str = DEFAULT_OP
     req = _build_prompt_update_request(current_prompt, context)
 
     try:
-        resp = client.chat.completions.create(
+        resp = llm.create_completion(
+            client,
             model=model,
             **llm._completion_token_kwargs(model, 400),
             messages=[

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -102,7 +102,9 @@ def test_load_key_missing_raises():
 def test_make_client():
     with mock.patch("ouroboros.llm.OpenAI") as MockOpenAI:
         client = make_client("sk-test")
-    MockOpenAI.assert_called_once_with(api_key="sk-test")
+    # max_retries=0: retry.retry_with_backoff owns retrying. The SDK's default
+    # of 2 would compound with ours (4 x 3 = up to 12 transmissions).
+    MockOpenAI.assert_called_once_with(api_key="sk-test", max_retries=0)
     assert client is MockOpenAI.return_value
 
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,628 @@
+"""Tests for retry with exponential backoff and jitter."""
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from ouroboros.retry import (
+    DEFAULT_MAX_ATTEMPTS,
+    is_idempotent_request,
+    backoff_delay,
+    is_retryable,
+    retry_with_backoff,
+)
+
+
+class _Recorder:
+    """Stand-in for time.sleep that records the delays instead of waiting."""
+
+    def __init__(self):
+        self.delays = []
+
+    def __call__(self, delay):
+        self.delays.append(delay)
+
+
+# -- is_retryable ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        TimeoutError("timed out"),
+        ConnectionError("connection reset"),
+        ConnectionResetError("reset"),
+        urllib.error.URLError("no route to host"),
+    ],
+)
+def test_is_retryable_transport_failures(exc):
+    assert is_retryable(exc) is True
+
+
+@pytest.mark.parametrize(
+    "code", [408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524]
+)
+def test_is_retryable_transient_status_codes(code):
+    exc = urllib.error.HTTPError("u", code, "msg", {}, None)
+    assert is_retryable(exc) is True
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404, 409, 422, 507, 508])
+def test_is_not_retryable_client_errors(code):
+    """Retrying a bad request, a bad key, or a conflict just burns quota.
+
+    409 is a deterministic statement about state; 507/508 do not clear on
+    their own.
+    """
+    exc = urllib.error.HTTPError("u", code, "msg", {}, None)
+    assert is_retryable(exc) is False
+
+
+@pytest.mark.parametrize(
+    "exc", [ValueError("nope"), KeyError("k"), RuntimeError("boom")]
+)
+def test_is_not_retryable_ordinary_exceptions(exc):
+    assert is_retryable(exc) is False
+
+
+def test_is_retryable_openai_rate_limit():
+    openai = pytest.importorskip("openai")
+    exc = openai.RateLimitError.__new__(openai.RateLimitError)
+    assert is_retryable(exc) is True
+
+
+def test_is_retryable_openai_bad_request_is_not():
+    openai = pytest.importorskip("openai")
+    exc = openai.BadRequestError.__new__(openai.BadRequestError)
+    assert is_retryable(exc) is False
+
+
+def test_is_retryable_uses_status_code_attribute():
+    class Weird(Exception):
+        status_code = 503
+
+    assert is_retryable(Weird()) is True
+
+    class WeirdClient(Exception):
+        status_code = 400
+
+    assert is_retryable(WeirdClient()) is False
+
+
+# -- backoff_delay -----------------------------------------------------------
+
+def test_backoff_delay_ceiling_grows_exponentially():
+    ceilings = [
+        backoff_delay(n, base_delay=1.0, max_delay=30.0, rng=lambda lo, hi: hi)
+        for n in range(1, 6)
+    ]
+    assert ceilings == [1.0, 2.0, 4.0, 8.0, 16.0]
+
+
+def test_backoff_delay_respects_max_delay():
+    ceiling = backoff_delay(20, base_delay=1.0, max_delay=30.0, rng=lambda lo, hi: hi)
+    assert ceiling == 30.0
+
+
+def test_backoff_delay_uses_full_jitter():
+    """Uniform over [0, ceiling] -- not ceiling plus a nudge."""
+    assert backoff_delay(3, rng=lambda lo, hi: lo) == 0.0
+    seen = {round(backoff_delay(4), 6) for _ in range(200)}
+    assert len(seen) > 50, "delay should be jittered, not constant"
+    assert all(0.0 <= d <= 8.0 for d in seen)
+
+
+# -- retry_with_backoff ------------------------------------------------------
+
+def test_returns_immediately_on_success():
+    sleep = _Recorder()
+    calls = []
+
+    @retry_with_backoff(sleep=sleep)
+    def fn():
+        calls.append(1)
+        return "ok"
+
+    assert fn() == "ok"
+    assert len(calls) == 1
+    assert sleep.delays == []
+
+
+def test_retries_then_succeeds():
+    sleep = _Recorder()
+    calls = []
+
+    @retry_with_backoff(sleep=sleep)
+    def fn():
+        calls.append(1)
+        if len(calls) < 3:
+            raise TimeoutError("transient")
+        return "ok"
+
+    assert fn() == "ok"
+    assert len(calls) == 3
+    assert len(sleep.delays) == 2
+
+
+def test_gives_up_after_max_attempts_and_reraises():
+    """The final failure propagates; callers already handle errors."""
+    sleep = _Recorder()
+    calls = []
+
+    @retry_with_backoff(max_attempts=3, sleep=sleep)
+    def fn():
+        calls.append(1)
+        raise TimeoutError("always down")
+
+    with pytest.raises(TimeoutError, match="always down"):
+        fn()
+
+    assert len(calls) == 3
+    assert len(sleep.delays) == 2  # no sleep after the last attempt
+
+
+def test_does_not_retry_non_retryable():
+    sleep = _Recorder()
+    calls = []
+
+    @retry_with_backoff(sleep=sleep)
+    def fn():
+        calls.append(1)
+        raise ValueError("bad request")
+
+    with pytest.raises(ValueError):
+        fn()
+
+    assert len(calls) == 1
+    assert sleep.delays == []
+
+
+def test_default_attempt_count():
+    sleep = _Recorder()
+    calls = []
+
+    @retry_with_backoff(sleep=sleep)
+    def fn():
+        calls.append(1)
+        raise TimeoutError()
+
+    with pytest.raises(TimeoutError):
+        fn()
+    assert len(calls) == DEFAULT_MAX_ATTEMPTS
+
+
+def test_preserves_function_metadata_and_arguments():
+    @retry_with_backoff(sleep=_Recorder())
+    def add(a, b, *, c=0):
+        """Adds things."""
+        return a + b + c
+
+    assert add.__name__ == "add"
+    assert add.__doc__ == "Adds things."
+    assert add(1, 2, c=3) == 6
+
+
+def test_custom_retryable_predicate():
+    sleep = _Recorder()
+    calls = []
+
+    @retry_with_backoff(max_attempts=3, sleep=sleep, retryable=lambda e: True)
+    def fn():
+        calls.append(1)
+        raise ValueError("normally not retryable")
+
+    with pytest.raises(ValueError):
+        fn()
+    assert len(calls) == 3
+
+
+# -- wiring: the retry actually applies to the real call paths ---------------
+
+def test_llm_completions_retry_transient_failures(monkeypatch):
+    """Every llm.py completion goes through one retrying chokepoint."""
+    from ouroboros import llm, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class FlakyCompletions:
+        def create(self, **kwargs):
+            attempts.append(kwargs)
+            if len(attempts) < 3:
+                raise TimeoutError("transient")
+            return _completion_response("recovered")
+
+    client = _client_with(FlakyCompletions())
+    content, _usage = llm.chat_completion(client, "sys", "user", model="gpt-test")
+
+    assert content == "recovered"
+    assert len(attempts) == 3
+
+
+def test_llm_completions_do_not_retry_bad_requests(monkeypatch):
+    from ouroboros import llm, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class BadCompletions:
+        def create(self, **kwargs):
+            attempts.append(kwargs)
+            raise ValueError("invalid model")
+
+    # chat_completion swallows the failure and returns ("", None) as before.
+    content, usage = llm.chat_completion(
+        _client_with(BadCompletions()), "sys", "user", model="gpt-test"
+    )
+
+    assert (content, usage) == ("", None)
+    assert len(attempts) == 1
+
+
+def test_moltbook_request_retries_transient_http(monkeypatch):
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class FakeResponse:
+        def read(self):
+            return b'{"ok": true}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def flaky_urlopen(req, timeout=None):
+        attempts.append(req)
+        if len(attempts) < 3:
+            raise urllib.error.HTTPError("u", 503, "unavailable", {}, None)
+        return FakeResponse()
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", flaky_urlopen)
+
+    assert moltbook._request("GET", "/x", "key") == {"ok": True}
+    assert len(attempts) == 3
+
+
+def test_moltbook_request_does_not_retry_auth_failure(monkeypatch):
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    def unauthorized(req, timeout=None):
+        attempts.append(req)
+        raise urllib.error.HTTPError("u", 401, "unauthorized", {}, None)
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", unauthorized)
+
+    with pytest.raises(moltbook.MoltbookError):
+        moltbook._request("GET", "/x", "key")
+    assert len(attempts) == 1
+
+
+def test_moltbook_request_still_wraps_the_final_error(monkeypatch):
+    """Exhausting retries must still surface as MoltbookError, as before."""
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+
+    def always_down(req, timeout=None):
+        raise urllib.error.HTTPError("u", 503, "unavailable", {}, None)
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", always_down)
+
+    with pytest.raises(moltbook.MoltbookError, match="Request failed"):
+        moltbook._request("GET", "/x", "key")
+
+
+# -- helpers -----------------------------------------------------------------
+
+def _completion_response(text):
+    class Message:
+        content = text
+        tool_calls = None
+
+    class Choice:
+        message = Message()
+
+    class Response:
+        choices = [Choice()]
+        usage = None
+
+    return Response()
+
+
+def _client_with(completions):
+    class Chat:
+        pass
+
+    chat = Chat()
+    chat.completions = completions
+
+    class Client:
+        pass
+
+    client = Client()
+    client.chat = chat
+    return client
+
+
+def test_sleep_is_resolved_at_call_time_not_decoration_time(monkeypatch):
+    """Otherwise a decorated call site can never be tested without real waits."""
+    from ouroboros import retry
+
+    @retry_with_backoff(max_attempts=2)
+    def fn():
+        raise TimeoutError("transient")
+
+    recorded = []
+    monkeypatch.setattr(retry.time, "sleep", lambda d: recorded.append(d))
+
+    with pytest.raises(TimeoutError):
+        fn()
+
+    assert len(recorded) == 1, "patching retry.time.sleep must take effect"
+
+
+# -- idempotency: replaying a write can duplicate it -------------------------
+
+@pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS", "PUT", "DELETE"])
+def test_idempotent_methods_are_replayable(method):
+    req = urllib.request.Request("https://x/y", method=method)
+    assert is_idempotent_request(req) is True
+
+
+@pytest.mark.parametrize("method", ["POST", "PATCH"])
+def test_write_methods_are_not_replayable(method):
+    req = urllib.request.Request("https://x/y", data=b"{}", method=method)
+    assert is_idempotent_request(req) is False
+
+
+def test_unknown_request_shape_is_treated_as_unsafe():
+    """A missed retry costs a cycle; a wrong one costs a duplicate post."""
+    assert is_idempotent_request(object()) is False
+
+
+def test_moltbook_does_not_retry_post(monkeypatch):
+    """create_post must never be replayed -- the server may have committed it."""
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    def flaky(req, timeout=None):
+        attempts.append(req.get_method())
+        raise urllib.error.HTTPError("u", 503, "unavailable", {}, None)
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", flaky)
+
+    with pytest.raises(moltbook.MoltbookError):
+        moltbook.create_post("key", "general", "title", "body")
+
+    assert attempts == ["POST"], "a POST must be sent exactly once"
+
+
+def test_moltbook_does_not_retry_comment(monkeypatch):
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    def flaky(req, timeout=None):
+        attempts.append(req.get_method())
+        raise TimeoutError("response lost after the server committed")
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", flaky)
+
+    with pytest.raises(moltbook.MoltbookError):
+        moltbook.create_comment("key", "post-1", "hello")
+
+    assert attempts == ["POST"]
+
+
+def test_moltbook_still_retries_reads(monkeypatch):
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class FakeResponse:
+        def read(self):
+            return b'{"posts": []}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def flaky(req, timeout=None):
+        attempts.append(req.get_method())
+        if len(attempts) < 3:
+            raise urllib.error.HTTPError("u", 429, "slow down", {}, None)
+        return FakeResponse()
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", flaky)
+
+    assert moltbook.get_feed("key") == {"posts": []}
+    assert attempts == ["GET", "GET", "GET"]
+
+
+# -- shutdown ----------------------------------------------------------------
+
+def test_retry_stops_when_cancelled():
+    """An outage must not hold the process past SIGTERM."""
+    sleep = _Recorder()
+    calls = []
+    cancelled = []
+
+    @retry_with_backoff(max_attempts=4, sleep=sleep, cancelled=lambda: bool(cancelled))
+    def fn():
+        calls.append(1)
+        cancelled.append(True)  # shutdown requested during attempt 1
+        raise TimeoutError("service down")
+
+    with pytest.raises(TimeoutError):
+        fn()
+
+    assert len(calls) == 1, "must not start another attempt after shutdown"
+    assert sleep.delays == [], "must not sleep after shutdown"
+
+
+def test_retry_stops_when_cancelled_during_backoff():
+    calls = []
+    flag = []
+
+    def sleep_then_cancel(_delay):
+        flag.append(True)
+
+    @retry_with_backoff(max_attempts=4, sleep=sleep_then_cancel, cancelled=lambda: bool(flag))
+    def fn():
+        calls.append(1)
+        raise TimeoutError("service down")
+
+    with pytest.raises(TimeoutError):
+        fn()
+
+    assert len(calls) == 1
+
+
+def test_moltbook_retry_is_wired_to_the_shutdown_event(monkeypatch):
+    from ouroboros import moltbook, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    def flaky(req, timeout=None):
+        attempts.append(1)
+        moltbook._shutdown_event.set()
+        raise urllib.error.HTTPError("u", 503, "unavailable", {}, None)
+
+    monkeypatch.setattr(moltbook.urllib.request, "urlopen", flaky)
+    try:
+        with pytest.raises(moltbook.MoltbookError):
+            moltbook.get_feed("key")
+        assert len(attempts) == 1
+    finally:
+        moltbook._shutdown_event.clear()
+
+
+# -- no completion call may bypass the chokepoint ----------------------------
+
+def test_no_module_calls_chat_completions_create_directly():
+    """Every completion must route through llm.create_completion for retries."""
+    import ast
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parent.parent / "src" / "ouroboros"
+    offenders = []
+    for path in sorted(src.rglob("*.py")):
+        if path.name in {"llm.py", "backends.py"}:
+            continue  # llm defines the entrypoint; backends duck-types the API
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            f = node.func
+            if (
+                isinstance(f, ast.Attribute)
+                and f.attr == "create"
+                and isinstance(f.value, ast.Attribute)
+                and f.value.attr == "completions"
+            ):
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert offenders == [], (
+        "these bypass llm.create_completion and so get no retries: "
+        + ", ".join(offenders)
+    )
+
+
+# -- one retry owner, one budget, one shutdown -------------------------------
+
+def test_reviewer_endpoint_client_disables_sdk_retries(monkeypatch):
+    """Otherwise the SDK's 2 compound with our 4 -- up to 12 transmissions."""
+    from ouroboros import backends
+
+    built = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    backends.make_backend_client(
+        "openai", openai_client=object(), base_url="https://ollama.com/v1"
+    )
+    assert built["max_retries"] == 0
+
+
+def test_llm_retries_stop_on_shutdown(monkeypatch):
+    """SIGTERM during an LLM outage must not cost three more attempts."""
+    from ouroboros import lifecycle, llm, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class Completions:
+        def create(self, **kwargs):
+            attempts.append(kwargs)
+            lifecycle.request_shutdown()
+            raise TimeoutError("service down")
+
+    try:
+        content, usage = llm.chat_completion(
+            _client_with(Completions()), "sys", "user", model="gpt-test"
+        )
+        assert (content, usage) == ("", None)
+        assert len(attempts) == 1
+    finally:
+        lifecycle.reset()
+
+
+def test_identify_does_not_double_the_retry_budget(monkeypatch):
+    """A transport outage costs four attempts total, not eight."""
+    from ouroboros import llm, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class Completions:
+        def create(self, **kwargs):
+            attempts.append(kwargs)
+            raise TimeoutError("service down")
+
+    result, err = llm.identify_improvements(
+        _client_with(Completions()), "summary", "tests", "history", model="gpt-test"
+    )
+
+    assert result is None
+    assert err is not None
+    assert len(attempts) == retry.DEFAULT_MAX_ATTEMPTS
+
+
+def test_identify_still_falls_back_for_non_transport_failures(monkeypatch):
+    """A capability or shape problem is exactly what the fallback is for."""
+    from ouroboros import llm, retry
+
+    monkeypatch.setattr(retry.time, "sleep", lambda _d: None)
+    attempts = []
+
+    class Completions:
+        def create(self, **kwargs):
+            attempts.append(kwargs)
+            if "tools" in kwargs:
+                raise ValueError("this model does not support tools")
+            return _completion_response('{"task_type": "fix_bug"}')
+
+    result, err = llm.identify_improvements(
+        _client_with(Completions()), "summary", "tests", "history", model="gpt-test"
+    )
+
+    assert err is None
+    assert result["task_type"] == "fix_bug"
+    assert len(attempts) == 2  # one tool-call attempt, one plain-JSON fallback

--- a/tests/test_reviewer_backend_routing.py
+++ b/tests/test_reviewer_backend_routing.py
@@ -25,9 +25,10 @@ def test_make_backend_client_builds_a_client_for_a_compatible_endpoint(monkeypat
     built = {}
 
     class FakeOpenAI:
-        def __init__(self, api_key=None, base_url=None):
+        def __init__(self, api_key=None, base_url=None, max_retries=None):
             built["api_key"] = api_key
             built["base_url"] = base_url
+            built["max_retries"] = max_retries
 
     monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
     sentinel = object()
@@ -42,7 +43,11 @@ def test_make_backend_client_builds_a_client_for_a_compatible_endpoint(monkeypat
 
     assert client is not sentinel
     assert isinstance(client, FakeOpenAI)
-    assert built == {"api_key": "secret", "base_url": "https://ollama.com/v1"}
+    assert built == {
+        "api_key": "secret",
+        "base_url": "https://ollama.com/v1",
+        "max_retries": 0,
+    }
 
 
 def test_make_backend_client_falls_back_when_endpoint_client_fails(monkeypatch):


### PR DESCRIPTION
Closes #10.

## Problem

Neither the LLM calls nor the Moltbook HTTP calls retried at all. A 429 or a dropped connection on the Pi failed the task and skipped the cycle. The only backoff in the codebase was in `run_loop`, which reacts to a whole cycle failing rather than to one request.

## Fix

`retry.retry_with_backoff`, applied at two chokepoints: `llm.create_completion` (every completion now routes through it) and moltbook's request path. Four attempts, 1s base, 30s cap, **full jitter** — uniform over `[0, capped exponential]` rather than exponential plus a nudge, because several agents retrying a shared rate limit in lockstep is the failure worth avoiding.

## Three things a naive retry would have broken

**1. Writes must not be replayed.** A `POST` the server committed but whose response was lost is indistinguishable from one it never received — and this API creates *public posts and comments*. Replaying one duplicates it, with nothing to reconcile against since state is only recorded after a response. There's no idempotency key available, so only `GET`/`HEAD`/`OPTIONS`/`TRACE`/`PUT`/`DELETE` are retried, and an unrecognised request shape counts as unsafe. A missed retry costs a cycle; a wrong one costs a duplicate public post.

**2. Retries must stop on shutdown.** Four attempts × (20s timeout + up to 30s backoff) — or the SDK's 600s read timeout — would hold the process well past SIGTERM and could issue writes after shutdown was requested. `retry_with_backoff` takes a cancellation predicate, polled before each wait and before each further attempt. The shutdown flag moves into a new `lifecycle` module so `llm` and `moltbook` can both observe it without importing each other; `moltbook._shutdown_event` is now an alias.

**3. Only one component may own retrying.** The OpenAI SDK defaults to `max_retries=2`, which compounds with our 4 into **up to 12 transmissions** for one logical call, under an outer backoff blind to the inner ones. Every OpenAI constructor now passes `max_retries=0` — both `llm.make_client` and the reviewer-endpoint client in `backends`. Relatedly, `identify_improvements`' fallback used to run a *second* full retry loop after the first exhausted; it now returns the error for transport failures and keeps the fallback for capability/parsing failures, which is what it can actually fix.

## Classification

Retried: 408/425/429/5xx incl. Cloudflare 52x, mid-stream failures (`IncompleteRead`, `BadStatusLine` → `RemoteDisconnected`), dropped connections, timeouts, and the SDK's `RateLimitError`/`APIConnectionError`/`APITimeoutError`/`InternalServerError`.

Not retried: 400/401/403/404/422; **409** (a conflict is a deterministic statement about state); **507/508** (don't clear on their own); **TLS failures** — a bad certificate is a trust problem, and `URLError.reason` is unwrapped so it can't slip through as a generic transport error.

The final failure propagates rather than being swallowed — callers already handle failure, and hiding it would turn an outage into silently missing data.

## Two design notes

- The retry sits *below* moltbook's `MoltbookError` wrapper, because wrapping first would hide the original exception type from `is_retryable`.
- `sleep` is resolved at call time, not bound as a default argument. Binding captures `time.sleep` at import, so no decorated call site could be tested without waiting out the real backoff — these tests took 8s before that was fixed, and are now instant.

## Guard against regression

A test walks the AST of every module and fails if any calls `chat.completions.create` directly, so a new call site can't quietly opt out of retries. Three already had — two in `improvement.py`'s ReAct loop, one in `self_improve.py` — all now routed.

## Verification

`476 passed` locally, 3.10–3.14 in CI. 60 new tests, including: `create_post`/`create_comment` send exactly once under 503 and under timeout; reads still retry; shutdown during attempt 1 yields exactly one transmission for both LLM and HTTP; a persistent `TimeoutError` through `identify_improvements` costs 4 attempts, not 8.

## Review

Codex and Antigravity, three rounds. Both blocked round 1 on POST replay and shutdown — correct, and fixed. Codex then found the reviewer-endpoint client still had SDK retries enabled, that LLM retries weren't wired to the shutdown event, and the doubled identify budget; all three verified and fixed. Classification changes (409, 52x, `IncompleteRead`, TLS) came from both reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm