### PR TITLE
feat(llm): bound every request to the model's input budget

### DIFF
--- a/src/ouroboros/backends.py
+++ b/src/ouroboros/backends.py
@@ -360,13 +360,28 @@ def _untracked_files(repo: Path) -> set:
     return {_decode_git_path(line) for line in proc.stdout.splitlines() if line.strip()}
 
 
-def _build_agent_prompt(task: Any, plan: str, config: Any) -> str:
+def _build_agent_prompt(task: Any, plan: str, config: Any, model: Optional[str] = None) -> str:
+    """Build the CLI agent prompt, bounded to the target model's budget.
+
+    CLI backends take a prompt string rather than a message list, so they do
+    not pass through llm.create_completion. The description and plan are
+    model-generated and unbounded, so the same ceiling is applied here --
+    otherwise the configured generator_backend is a live path with no cap.
+    """
+    from .llm import model_input_budget, truncate_to_tokens  # local: avoids a cycle
+
+    budget = model_input_budget(model or "")
+    description = truncate_to_tokens(
+        str(getattr(task, "description", "")), budget // 4, label="task description"
+    )
+    plan = truncate_to_tokens(plan, budget // 2, label="plan")
+
     forbidden = ", ".join(getattr(config, "forbidden_modification_paths", ()))
     allowed = ", ".join(getattr(config, "allowed_modification_paths", ()))
     return (
         "You are working inside a git repository. Implement the improvement below "
         "by editing files directly in the working tree.\n\n"
-        f"## Task ({getattr(task, 'task_type', '')})\n{getattr(task, 'description', '')}\n\n"
+        f"## Task ({getattr(task, 'task_type', '')})\n{description}\n\n"
         f"## Plan\n{plan}\n\n"
         "## Hard constraints (violating any of these causes your work to be discarded)\n"
         f"- Modify at most {getattr(config, 'max_changed_files_per_pr', 3)} files.\n"
@@ -446,7 +461,7 @@ def agent_generate_changes(
 
     repo = Path(repo_root)
     untracked_before = _untracked_files(repo)
-    prompt = _build_agent_prompt(task, plan, config)
+    prompt = _build_agent_prompt(task, plan, config, model)
 
     try:
         if backend == "claude":

--- a/src/ouroboros/llm.py
+++ b/src/ouroboros/llm.py
@@ -60,8 +60,98 @@ def create_completion(client: Any, **kwargs: Any) -> Any:
     Transient faults (429, 5xx, dropped connections, timeouts) are retried with
     exponential backoff and jitter; everything else propagates on the first
     attempt. See retry.is_retryable.
+
+    Messages are also fitted to the model's input budget here. Doing it at the
+    call sites alone would only cover the prompts someone remembered to cap --
+    and would miss the ReAct loop, whose tool results are appended to a message
+    history that is resent whole.
     """
+    messages = kwargs.get("messages")
+    if messages:
+        kwargs["messages"] = fit_messages_to_budget(messages, kwargs.get("model", ""))
     return client.chat.completions.create(**kwargs)
+
+
+def fit_messages_to_budget(
+    messages: List[Dict[str, Any]], model: str
+) -> List[Dict[str, Any]]:
+    """Trim message contents so the request fits the model's input budget.
+
+    Trims the largest message first and re-measures, so one oversized blob is
+    cut rather than every message being shaved evenly. System messages are
+    left alone unless nothing else is left to give: they carry the
+    instructions, and losing those changes what the model is being asked to
+    do.
+    """
+    budget = model_input_budget(model)
+    if _messages_tokens(messages) <= budget:
+        return messages
+
+    trimmed = [dict(m) for m in messages]
+
+    def _reduce(indices: List[int]) -> None:
+        # Largest first, re-measuring each time, so one oversized blob is cut
+        # rather than every message shaved evenly.
+        for _ in range(len(indices) * 2):
+            total = _messages_tokens(trimmed)
+            if total <= budget:
+                return
+            candidates = [i for i in indices if trimmed[i].get("content")]
+            if not candidates:
+                return
+            biggest = max(candidates, key=lambda i: len(trimmed[i]["content"]))
+            content = trimmed[biggest]["content"]
+            target = max(estimate_tokens(content) - (total - budget), 0)
+            reduced = truncate_to_tokens(content, target, label="prompt")
+            if reduced == content:
+                return  # cannot shrink further
+            trimmed[biggest]["content"] = reduced
+
+    is_text = [i for i, m in enumerate(trimmed) if isinstance(m.get("content"), str)]
+    _reduce([i for i in is_text if trimmed[i].get("role") != "system"])
+    # Only if trimming everything else still does not fit. The system message
+    # carries the instructions, so losing it changes what is being asked --
+    # but a request that cannot be sent is worse.
+    _reduce([i for i in is_text if trimmed[i].get("role") == "system"])
+
+    final = _messages_tokens(trimmed)
+    log.warning(
+        "prompt exceeded the %s input budget (%d tokens); trimmed to ~%d",
+        model or "default",
+        budget,
+        final,
+    )
+    if final > budget:
+        log.error(
+            "prompt still over budget after trimming (~%d > %d); "
+            "non-text content dominates the request",
+            final,
+            budget,
+        )
+    return trimmed
+
+
+def _message_tokens(message: Dict[str, Any]) -> int:
+    """Estimate a message's cost, including non-string parts.
+
+    tool_calls and structured content carry real tokens. Counting only string
+    content would report a message with a 100k-character tool-call argument as
+    free, and the budget check would pass on a request that cannot be sent.
+    """
+    total = 0
+    for key, value in message.items():
+        if isinstance(value, str):
+            total += estimate_tokens(value)
+        elif value is not None:
+            try:
+                total += estimate_tokens(json.dumps(value, default=str))
+            except (TypeError, ValueError):
+                total += estimate_tokens(str(value))
+    return total
+
+
+def _messages_tokens(messages: List[Dict[str, Any]]) -> int:
+    return sum(_message_tokens(m) for m in messages)
 
 
 # Backwards-compatible private alias.
@@ -73,6 +163,128 @@ def _completion_token_kwargs(model: str, max_tokens: int) -> dict:
     if model.startswith("gpt-5"):
         return {"max_completion_tokens": max_tokens}
     return {"max_tokens": max_tokens}
+
+
+# -- Prompt sizing -----------------------------------------------------------
+#
+# The agent injects whole-codebase summaries and full test output into prompts.
+# Both grow with the repo, so without a ceiling the request eventually exceeds
+# the model's context window and every cycle fails with a 400.
+
+# Characters per token. 4 is the usual English rule of thumb, but this mostly
+# carries Python source and pytest output, where dense punctuation pushes the
+# real ratio nearer 2.5-3. Estimating low is the safe direction: it yields a
+# slightly smaller prompt rather than one that overflows.
+CHARS_PER_TOKEN = 3
+
+# Input budget per model, in tokens. The value is the context window minus
+# generous room for the reply, since these are input-side limits.
+_MODEL_INPUT_BUDGETS = (
+    ("gpt-5", 300_000),
+    ("gpt-4.1", 800_000),
+    ("gpt-4o", 100_000),
+    ("gpt-4", 100_000),
+    ("claude", 150_000),
+    # Local Ollama models are typically 8k-32k; assume the small end.
+    ("gemma", 6_000),
+    ("qwen", 24_000),
+    ("llama", 6_000),
+    ("ollama/", 6_000),
+)
+
+# Used when the model is unrecognised. Deliberately modest: overshooting a
+# small local model's window fails the request, while undershooting a large
+# one only trims context.
+DEFAULT_MAX_REQUEST_TOKENS = 48_000
+
+# Per-section ceilings, applied where prompts are assembled. These are a
+# backstop against one section crowding out the others; the request-wide
+# budget enforced in create_completion is what actually guarantees the window
+# is respected.
+MAX_CODEBASE_SUMMARY_TOKENS = 24_000
+MAX_TEST_OUTPUT_TOKENS = 6_000
+MAX_HISTORY_TOKENS = 4_000
+MAX_CODE_CONTEXT_TOKENS = 24_000
+
+
+def estimate_tokens(text: str) -> int:
+    """Approximate the token count of text."""
+    if not text:
+        return 0
+    return (len(text) + CHARS_PER_TOKEN - 1) // CHARS_PER_TOKEN
+
+
+def model_input_budget(model: str) -> int:
+    """Return the input-token budget for model."""
+    name = (model or "").lower()
+    for prefix, budget in _MODEL_INPUT_BUDGETS:
+        if name.startswith(prefix):
+            return budget
+    return DEFAULT_MAX_REQUEST_TOKENS
+
+
+def _cut_at_line_start(text: str) -> str:
+    """Drop a trailing partial line, unless there is no line structure at all."""
+    return text[: text.rindex("\n") + 1] if "\n" in text else text
+
+
+def _cut_to_line_start(text: str) -> str:
+    """Drop a leading partial line, unless there is no line structure at all."""
+    return text[text.index("\n") + 1:] if "\n" in text else text
+
+
+def truncate_to_tokens(text: str, max_tokens: int, *, label: str = "content") -> str:
+    """Trim text to roughly max_tokens, keeping the start and the end.
+
+    Middle-out rather than a plain head cut, because for the things this
+    truncates both ends carry the signal: a codebase summary's tail lists
+    modules the head does not, and pytest output puts the first failure at the
+    top and the summary line at the bottom. Cutting the tail would routinely
+    discard the part naming what actually failed.
+
+    Cuts land on line boundaries. Fenced content is truncated head-only
+    instead: splicing a head onto a tail can leave one file's opening fence
+    joined to another file's closing fence, so the model reads the second
+    file's code under the first file's heading. Balancing the fence count
+    would make that look well-formed while still being wrong, and
+    structurally false context is worse than less context.
+
+    The elision is marked so the model is told the input was abridged rather
+    than silently seeing a partial picture.
+    """
+    if max_tokens <= 0 or not text:
+        return ""
+
+    budget = max_tokens * CHARS_PER_TOKEN
+    if len(text) <= budget:
+        return text
+
+    dropped = len(text) - budget
+    marker = f"\n\n... [{label} truncated: {dropped:,} of {len(text):,} characters omitted] ...\n\n"
+    remaining = budget - len(marker)
+    if remaining <= 0:
+        # The marker alone would exceed the budget. Returning it anyway would
+        # make this function overshoot the limit it exists to enforce, so drop
+        # the annotation and hard-cut instead.
+        return text[:budget]
+
+    if "```" in text:
+        # Head-only: never join two fenced regions that were not adjacent.
+        head = _cut_at_line_start(text[:remaining])
+        if head.count("```") % 2:
+            # The cut landed inside a fence; drop back to before it opened.
+            head = head[: head.rindex("```")]
+        return head + marker
+
+    # Favour the head slightly: it holds the overview, the tail holds the
+    # summary line.
+    head_len = (remaining * 2) // 3
+    tail_len = remaining - head_len
+
+    head = _cut_at_line_start(text[:head_len])
+    tail = _cut_to_line_start(text[-tail_len:]) if tail_len > 0 else ""
+
+    return head + marker + tail
 
 
 
@@ -138,6 +350,13 @@ def identify_improvements(
         "- Do not repeat a task that the recent history shows already failed the same way.\n\n"
         "Output JSON with keys: task_type, description, target_files, evidence, priority."
     )
+    summary = truncate_to_tokens(
+        summary, MAX_CODEBASE_SUMMARY_TOKENS, label="codebase summary"
+    )
+    test_results = truncate_to_tokens(
+        test_results, MAX_TEST_OUTPUT_TOKENS, label="test output"
+    )
+    history = truncate_to_tokens(history, MAX_HISTORY_TOKENS, label="history")
     user_prompt = f"## Summary\n{summary}\n\n## Tests\n{test_results}\n\n## History\n{history}\n\n{additional_context}"
 
     try:
@@ -293,7 +512,7 @@ def generate_question_post(
             **_completion_token_kwargs(model, 600),
             messages=[
                 {"role": "system", "content": prompts.load_question_post_prompt()},
-                {"role": "user", "content": f"## Task\n{task_data}\n\n## Code\n{code_block}\n\n## Tests\n{test_failures}"}
+                {"role": "user", "content": f"## Task\n{task_data}\n\n## Code\n{truncate_to_tokens(code_block, MAX_CODE_CONTEXT_TOKENS, label='code context')}\n\n## Tests\n{truncate_to_tokens(test_failures, MAX_TEST_OUTPUT_TOKENS, label='test output')}"}
             ]
         )
         return json.loads(resp.choices[0].message.content)
@@ -538,6 +757,9 @@ def generate_post(
 
 
 def generate_comment(client: Any, post_title: str, post_content: str, model: str = DEFAULT_OPENAI_MODEL, codebase_context: str = "") -> Optional[str]:
+    codebase_context = truncate_to_tokens(
+        codebase_context, MAX_CODEBASE_SUMMARY_TOKENS, label="codebase context"
+    )
     user_msg = f"Post title: {post_title}\n\nPost content: {post_content}\n\nContext: {codebase_context}"
     try:
         resp = create_completion(
@@ -553,6 +775,9 @@ def generate_comment(client: Any, post_title: str, post_content: str, model: str
         return None
 
 def answer_question(client: Any, question: str, codebase_summary: str = "", model: str = DEFAULT_OPENAI_MODEL) -> Optional[str]:
+    codebase_summary = truncate_to_tokens(
+        codebase_summary, MAX_CODEBASE_SUMMARY_TOKENS, label="codebase summary"
+    )
     user_content = f"## Codebase\n{codebase_summary}\n\n## Question\n{question}"
     try:
         resp = create_completion(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,7 +4,24 @@ from unittest import mock
 
 import pytest
 
-from ouroboros.llm import answer_question, generate_comment, load_openai_key, make_client
+from ouroboros.llm import (
+    CHARS_PER_TOKEN,
+    MAX_CODEBASE_SUMMARY_TOKENS,
+    MAX_HISTORY_TOKENS,
+    MAX_TEST_OUTPUT_TOKENS,
+    answer_question,
+    create_completion,
+    fit_messages_to_budget,
+    _message_tokens,
+    _messages_tokens,
+    model_input_budget,
+    estimate_tokens,
+    generate_comment,
+    identify_improvements,
+    load_openai_key,
+    make_client,
+    truncate_to_tokens,
+)
 from ouroboros.model_defaults import DEFAULT_OPENAI_MODEL
 
 
@@ -169,3 +186,279 @@ def test_answer_question_returns_none_on_error():
     client.chat.completions.create.side_effect = RuntimeError("fail")
     result = answer_question(client, "What is missing?")
     assert result is None
+
+
+# -- prompt sizing -----------------------------------------------------------
+
+def test_estimate_tokens():
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("a" * CHARS_PER_TOKEN) == 1
+    assert estimate_tokens("a" * (CHARS_PER_TOKEN * 1000)) == 1000
+    # Rounds up: a partial token still costs one.
+    assert estimate_tokens("a") == 1
+
+
+def test_chars_per_token_is_conservative_for_code():
+    """Dense Python runs nearer 2.5-3 chars/token than the English 4."""
+    assert CHARS_PER_TOKEN <= 3
+
+
+def test_truncate_returns_text_under_budget_unchanged():
+    text = "short enough"
+    assert truncate_to_tokens(text, 1000) == text
+
+
+def test_truncate_never_exceeds_the_budget():
+    """A truncation function that overshoots its limit is worse than none."""
+    import random
+    import string
+
+    for _ in range(2000):
+        n = random.randint(0, 3000)
+        budget = random.randint(0, 400)
+        text = "".join(
+            random.choice(string.ascii_letters + " \n") for _ in range(n)
+        )
+        out = truncate_to_tokens(text, budget, label="x")
+        assert len(out) <= budget * CHARS_PER_TOKEN, (n, budget, len(out))
+
+    # Fenced content too: closing an open fence must not push it over.
+    for _ in range(2000):
+        n = random.randint(0, 800)
+        budget = random.randint(0, 400)
+        text = "".join(
+            random.choice(["a", "\n", "```", "x = 1\n", "### f.py\n"])
+            for _ in range(n)
+        )
+        out = truncate_to_tokens(text, budget, label="x")
+        assert len(out) <= budget * CHARS_PER_TOKEN, (n, budget, len(out))
+
+
+def test_truncate_tiny_budget_drops_the_marker_rather_than_overshoot():
+    out = truncate_to_tokens("x" * 5000, 5, label="test output")
+    assert len(out) <= 5 * CHARS_PER_TOKEN
+    assert "truncated" not in out
+
+
+def test_truncate_keeps_head_and_tail():
+    """pytest puts the first failure at the top and the summary at the bottom."""
+    text = "FIRST-FAILURE" + ("filler " * 5000) + "SUMMARY-LINE"
+    out = truncate_to_tokens(text, 200, label="test output")
+
+    assert out.startswith("FIRST-FAILURE")
+    assert out.endswith("SUMMARY-LINE")
+    assert "truncated" in out
+
+
+def test_truncate_marker_reports_what_was_dropped():
+    out = truncate_to_tokens("x" * 10_000, 100, label="codebase summary")
+    assert "codebase summary truncated" in out
+    assert "characters omitted" in out
+
+
+@pytest.mark.parametrize("budget", [0, -1])
+def test_truncate_non_positive_budget_is_empty(budget):
+    assert truncate_to_tokens("anything", budget) == ""
+
+
+def test_truncate_empty_text():
+    assert truncate_to_tokens("", 100) == ""
+
+
+def test_identify_improvements_truncates_oversized_context():
+    """The whole-codebase summary must not reach the API unbounded."""
+    captured = {}
+
+    class Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            raise ValueError("stop here -- we only care about the prompt")
+
+    class Chat:
+        pass
+
+    chat = Chat()
+    chat.completions = Completions()
+
+    class Client:
+        pass
+
+    client = Client()
+    client.chat = chat
+
+    huge = "MODULE-A\n" + ("filler line\n" * 200_000) + "MODULE-Z\n"
+    identify_improvements(client, huge, "tests ok", "history", model="gpt-test")
+
+    sent = captured["messages"][1]["content"]
+    assert len(sent) < len(huge)
+    assert estimate_tokens(sent) <= (
+        MAX_CODEBASE_SUMMARY_TOKENS + MAX_TEST_OUTPUT_TOKENS + MAX_HISTORY_TOKENS + 500
+    )
+    # Both ends of the summary survive.
+    assert "MODULE-A" in sent
+    assert "MODULE-Z" in sent
+
+
+def test_truncate_cuts_on_line_boundaries():
+    text = "\n".join(f"line-{i}" for i in range(5000))
+    out = truncate_to_tokens(text, 100, label="x")
+    head = out.split("\n\n... [")[0]
+    # No partial line at the join.
+    assert head.endswith("\n") or head == ""
+    assert all(
+        line.startswith("line-") or line == ""
+        for line in head.splitlines()
+    )
+
+
+def test_truncate_balances_code_fences():
+    """A cut inside a fence must not leave it open, or the rest reads as code."""
+    text = "### a.py\n```python\n" + ("x = 1\n" * 20000) + "```\n"
+    out = truncate_to_tokens(text, 100, label="code context")
+    assert out.count("```") % 2 == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("gpt-5.4-nano-2026-03-17", 300_000),
+        ("gpt-4o", 100_000),
+        ("gemma4", 6_000),
+        ("qwen3-coder:480b-cloud", 24_000),
+        ("something-unknown", 48_000),
+        ("", 48_000),
+    ],
+)
+def test_model_input_budget(model, expected):
+    assert model_input_budget(model) == expected
+
+
+def test_fit_messages_leaves_a_small_request_untouched():
+    messages = [
+        {"role": "system", "content": "be helpful"},
+        {"role": "user", "content": "hello"},
+    ]
+    assert fit_messages_to_budget(messages, "gpt-5.4-nano") is messages
+
+
+def test_fit_messages_trims_to_the_model_budget():
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "x" * 400_000},
+        {"role": "tool", "content": "y" * 200_000},
+    ]
+    out = fit_messages_to_budget(messages, "gemma4")
+    total = sum(estimate_tokens(m["content"]) for m in out)
+    assert total <= model_input_budget("gemma4")
+
+
+def test_fit_messages_preserves_the_system_prompt():
+    """Losing the instructions changes what the model is being asked to do."""
+    system = "detailed instructions " * 100
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "x" * 400_000},
+    ]
+    out = fit_messages_to_budget(messages, "gemma4")
+    assert out[0]["content"] == system
+
+
+def test_fit_messages_does_not_mutate_the_input():
+    messages = [{"role": "user", "content": "x" * 400_000}]
+    original = messages[0]["content"]
+    fit_messages_to_budget(messages, "gemma4")
+    assert messages[0]["content"] == original
+
+
+def test_fit_messages_tolerates_non_string_content():
+    """Tool-call messages carry structured content, not text."""
+    messages = [
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]},
+        {"role": "user", "content": "x" * 400_000},
+    ]
+    out = fit_messages_to_budget(messages, "gemma4")
+    assert out[0]["content"] is None
+    assert out[0]["tool_calls"] == [{"id": "1"}]
+
+
+def test_create_completion_enforces_the_budget_for_every_path():
+    """The chokepoint bounds paths whose call site never truncates anything."""
+    captured = {}
+
+    class Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return None
+
+    class Chat:
+        pass
+
+    chat = Chat()
+    chat.completions = Completions()
+
+    class Client:
+        pass
+
+    client = Client()
+    client.chat = chat
+
+    create_completion(
+        client,
+        model="gemma4",
+        messages=[{"role": "user", "content": "x" * 500_000}],
+    )
+
+    sent = sum(estimate_tokens(m["content"]) for m in captured["messages"])
+    assert sent <= model_input_budget("gemma4")
+
+
+def test_fit_messages_trims_the_system_prompt_as_a_last_resort():
+    """A request that cannot be sent is worse than one missing instructions."""
+    messages = [
+        {"role": "system", "content": "S" * 30_000},
+        {"role": "user", "content": "ok"},
+    ]
+    out = fit_messages_to_budget(messages, "gemma4")
+    assert _messages_tokens(out) <= model_input_budget("gemma4")
+
+
+def test_message_tokens_counts_tool_call_payloads():
+    """A 100k-char tool-call argument is not free."""
+    message = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": "1", "function": {"arguments": "x" * 100_000}}],
+    }
+    assert _message_tokens(message) > 30_000
+
+
+def test_fenced_content_never_merges_two_files():
+    """Splicing head+tail can put b.py's code under a.py's heading."""
+    text = "### a.py\n```python\nA = 1\n" * 3000 + "### b.py\n```python\nB = 2\n```\n"
+    out = truncate_to_tokens(text, 100, label="code context")
+
+    # If b.py's code survived, its heading must have survived with it.
+    if "B = 2" in out:
+        assert "### b.py" in out
+    assert out.count("```") % 2 == 0
+
+
+def test_fenced_truncation_does_not_end_inside_a_fence():
+    text = "### a.py\n```python\n" + ("A = 1\n" * 20000) + "```\n"
+    out = truncate_to_tokens(text, 200, label="code context")
+    assert out.count("```") % 2 == 0
+
+
+def test_cli_agent_prompt_is_bounded():
+    """CLI backends take a string, so they bypass create_completion."""
+    from types import SimpleNamespace
+
+    from ouroboros.backends import _build_agent_prompt
+
+    task = SimpleNamespace(task_type="fix_bug", description="D" * 500_000)
+    config = SimpleNamespace(
+        forbidden_modification_paths=(), allowed_modification_paths=()
+    )
+    prompt = _build_agent_prompt(task, "P" * 500_000, config, model="gemma4")
+
+    assert estimate_tokens(prompt) <= model_input_budget("gemma4")


### PR DESCRIPTION
Closes #11.

## Problem

Nothing limited what went into a prompt. `get_codebase_summary` is already 43k characters and grows with the repo; test output, history, ReAct tool results and issue bodies are unbounded too. Several are concatenated into one request, so once the total passes the model's window **every cycle 400s** — and it arrives silently, as a function of repo size rather than of any change.

## Where the bound lives

In `create_completion` — the chokepoint every completion already routes through (established in #10).

Capping at individual call sites would only cover the prompts someone remembered to cap. It would miss the ReAct loop entirely: its tool results are appended to a message history that is resent whole, so a large file read blows the window straight after a bounded identification request succeeded. Enforcing at the chokepoint covers `community_improvement`, `github_improvement`, `additional_context`, knowledge-base payloads and everything else for free.

`fit_messages_to_budget` trims the largest message first and re-measures, so one oversized blob is cut rather than every message shaved evenly. Non-system messages go first; the system prompt is trimmed only if that isn't enough — losing instructions changes what's being asked, but a request that can't be sent is worse.

**Cost is measured over the whole message, not just string content.** A `tool_calls` argument of 100k characters would otherwise count as *zero* and the check would pass on an unsendable request. When non-text content alone exceeds the budget it's logged as an error rather than silently accepted — rewriting tool-call payloads would corrupt the protocol.

## Model-aware budgets

The range is enormous — 300k for gpt-5, **6k** for a local gemma. An unrecognised model gets a modest 48k: overshooting a small local window fails the request, undershooting a large one only trims context.

CLI agent backends take a prompt *string*, so they never reach `create_completion`. The configured `generator_backend` is `codex`, making that a live uncapped path — `_build_agent_prompt` now applies the same ceiling.

## Truncation shape

Middle-out on line boundaries, because both ends carry signal: a summary's tail lists modules the head doesn't, and pytest puts the first failure at the top and the summary line at the bottom.

**Except for fenced content, which is head-only.** Splicing a head onto a tail can leave `a.py`'s opening fence joined to `b.py`'s closing fence, so the model reads b.py's code under a.py's heading. An earlier draft balanced the fence count — which makes that *look* well-formed while still being wrong. Structurally false context is worse than less context.

`CHARS_PER_TOKEN` is 3, not the English 4: this mostly carries Python and pytest output, where dense punctuation puts the real ratio nearer 2.5–3. It remains an estimate, not a tokenizer (tiktoken is heavy for a Pi), which is why the budgets leave headroom.

## Verification

`506 passed` locally, 3.10–3.14 in CI.

A randomised test over 4000 cases including fenced and non-ASCII content asserts the output never exceeds the budget. That found two real bugs in my own code: the elision marker overshooting on small budgets, and the fence-closing appending past the limit.

## Review

Codex and Antigravity, three rounds. Round 1 both said per-section caps aren't a total bound — correct, and the restructure to the chokepoint came from that. Round 2 Codex demonstrated three concrete failures, all reproduced and fixed:

| Codex's case | before | now |
|---|---|---|
| 30k system + tiny user, gemma4 | 10,001 tokens vs 6,000 budget | fits at 6,000 |
| 100k-char `tool_calls` argument | counted as **0** | counted (33,351) and reported |
| multi-file fenced input | `B = 2` under `### a.py` | heading retained or code dropped |

Also from review: `CHARS_PER_TOKEN` 4→3, line-boundary cuts, and the CLI-backend bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm