### PR TITLE
refactor(storage): route backlog and evaluation through the JSON helpers

### DIFF
--- a/src/ouroboros/backlog.py
+++ b/src/ouroboros/backlog.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .model_defaults import DEFAULT_OPENAI_MODEL
+from .storage import load_json_file, save_json_file
 
 log = logging.getLogger(__name__)
 
@@ -19,26 +20,23 @@ def _backlog_path(repo_root: Path) -> Path:
 
 
 def load_backlog(repo_root: Path) -> List[Dict[str, Any]]:
-    path = _backlog_path(repo_root)
-    if not path.exists():
-        return []
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        return data.get("items", []) if isinstance(data, dict) else data
-    except (json.JSONDecodeError, KeyError):
-        log.warning("Corrupt backlog file, returning empty")
-        return []
+    data = load_json_file(
+        _backlog_path(repo_root),
+        default={"items": []},
+        error_msg="Corrupt backlog file, returning empty",
+        logger=log,
+    )
+    if isinstance(data, dict):
+        items = data.get("items")
+    else:
+        items = data
+    # A null or non-list payload is corruption, not an empty backlog's shape;
+    # returning it would break the annotated contract for every caller.
+    return items if isinstance(items, list) else []
 
 
 def save_backlog(repo_root: Path, items: List[Dict[str, Any]]) -> None:
-    path = _backlog_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = str(path) + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump({"items": items}, f, indent=2)
-    import os
-    os.replace(tmp, str(path))
+    save_json_file(_backlog_path(repo_root), {"items": items})
 
 
 def add_item(

--- a/src/ouroboros/evaluation.py
+++ b/src/ouroboros/evaluation.py
@@ -1,6 +1,5 @@
 """Outcome tracking for self-improvement attempts."""
 
-import json
 import logging
 import os
 import time
@@ -11,7 +10,13 @@ from typing import Dict, List, Optional, Tuple
 from . import git_ops
 from .codebase import get_repo_root
 from .model_defaults import DEFAULT_OPENAI_MODEL
-from .storage import OuroborosStorage, CycleRecord, MetricRecord
+from .storage import (
+    CycleRecord,
+    MetricRecord,
+    OuroborosStorage,
+    load_json_file,
+    save_json_file,
+)
 
 log = logging.getLogger(__name__)
 
@@ -85,8 +90,7 @@ def record_improvement(result: "ImprovementResult", repo_root: Optional[Path] = 
     )
     history.append(record)
 
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump([r.to_dict() for r in history], f, indent=2)
+    save_json_file(path, [r.to_dict() for r in history])
 
     # Persist to SQLite
     try:
@@ -116,16 +120,16 @@ def record_improvement(result: "ImprovementResult", repo_root: Optional[Path] = 
 
 def load_history(repo_root: Optional[Path] = None) -> List[EvaluationRecord]:
     """Load improvement history from disk."""
-    path = _history_path(repo_root)
-    if not path.exists():
+    data = load_json_file(
+        _history_path(repo_root),
+        default=[],
+        error_msg="Corrupt improvement history file, returning empty",
+        logger=log,
+    )
+    if not isinstance(data, list):
+        log.warning("Improvement history is not a list, returning empty")
         return []
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        return [EvaluationRecord.from_dict(d) for d in data]
-    except (json.JSONDecodeError, KeyError):
-        log.warning("Corrupt improvement history file, returning empty")
-        return []
+    return [EvaluationRecord.from_dict(d) for d in data]
 
 
 def check_pr_outcomes(repo_root: Optional[Path] = None) -> List[EvaluationRecord]:
@@ -160,9 +164,7 @@ def check_pr_outcomes(repo_root: Optional[Path] = None) -> List[EvaluationRecord
             log.debug("Could not check PR status for %s", record.pr_url)
 
     if updated:
-        path = _history_path(root)
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump([r.to_dict() for r in history], f, indent=2)
+        save_json_file(_history_path(root), [r.to_dict() for r in history])
 
     return history
 

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -361,9 +361,12 @@ def _default_state() -> Dict[str, Any]:
 
 
 def load_state() -> Dict[str, Any]:
+    # No os.path.exists() preflight: it answers False for any stat error, so a
+    # transient EACCES would look like a fresh install. run_loop persists what
+    # it loaded, so that would overwrite seen_post_ids and the cycle
+    # timestamps with defaults and the agent would repeat work it had already
+    # done. load_json_file distinguishes missing from unreadable.
     path = _state_path()
-    if not os.path.exists(path):
-        return _default_state()
     return load_json_file(
         path,
         default=_default_state(),

--- a/src/ouroboros/storage.py
+++ b/src/ouroboros/storage.py
@@ -24,17 +24,34 @@ def load_json_file(
     error_msg: Optional[str] = None,
     logger: Optional[logging.Logger] = None,
 ) -> Any:
-    """Load a JSON file, returning a default for missing or corrupt files."""
+    """Load a JSON file, returning a default for missing or corrupt files.
+
+    A read error other than "not there" propagates. Permission denied or a
+    failing disk means the data may well exist and simply could not be read;
+    handing back the default would let a caller that loads-modifies-writes
+    overwrite the real contents with an empty one.
+
+    The file is opened directly rather than probed with exists() first.
+    Path.exists() answers False for any stat error, so a preflight check
+    would quietly turn EACCES or EIO back into "missing" and reintroduce
+    exactly that overwrite.
+    """
     json_path = Path(path).expanduser()
-    if not json_path.exists():
+
+    try:
+        handle = json_path.open("r", encoding="utf-8")
+    except FileNotFoundError:
         if default is _MISSING:
-            raise FileNotFoundError(json_path)
+            raise
         return copy.deepcopy(default)
 
     try:
-        with json_path.open("r", encoding="utf-8") as f:
+        with handle as f:
             return json.load(f)
-    except (json.JSONDecodeError, KeyError, OSError):
+    except (json.JSONDecodeError, UnicodeDecodeError, KeyError):
+        # UnicodeDecodeError, not just JSONDecodeError: a file zeroed or filled
+        # with binary garbage by a crash never reaches the JSON parser, and
+        # that is precisely the corruption the default exists for.
         if default is _MISSING:
             raise
         if error_msg:

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -4,6 +4,9 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+
+import pytest
+
 from ouroboros.backlog import (
     load_backlog,
     save_backlog,
@@ -127,3 +130,77 @@ class TestBacklog:
         assert "[P10] feat: high" in formatted
         assert "[P1] fix: low (attempts: 2)" in formatted
         assert "done" not in formatted  # completed items should be excluded
+
+
+# -- centralised JSON IO -----------------------------------------------------
+
+def test_load_backlog_missing_file(tmp_path):
+    assert load_backlog(tmp_path) == []
+
+
+def test_load_backlog_corrupt_file(tmp_path):
+    path = tmp_path / "config" / "backlog.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{ not json")
+    assert load_backlog(tmp_path) == []
+
+
+def test_load_backlog_accepts_a_bare_list(tmp_path):
+    """Older files stored the list directly rather than under "items"."""
+    path = tmp_path / "config" / "backlog.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps([{"id": "1"}]))
+    assert load_backlog(tmp_path) == [{"id": "1"}]
+
+
+def test_save_backlog_creates_the_directory(tmp_path):
+    save_backlog(tmp_path, [{"id": "1"}])
+    assert (tmp_path / "config" / "backlog.json").exists()
+
+
+def test_backlog_round_trip(tmp_path):
+    items = [{"id": "a", "description": "x"}, {"id": "b", "description": "y"}]
+    save_backlog(tmp_path, items)
+    assert load_backlog(tmp_path) == items
+
+
+def test_save_backlog_leaves_no_temp_file(tmp_path):
+    save_backlog(tmp_path, [{"id": "1"}])
+    leftovers = list((tmp_path / "config").glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_unreadable_backlog_is_not_silently_replaced(tmp_path, monkeypatch):
+    """Returning [] here would let add_item overwrite a real backlog."""
+    from pathlib import Path as _Path
+
+    path = tmp_path / "config" / "backlog.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"items": [{"id": "keep-me"}]}))
+    original = path.read_text()
+
+    def unreadable(*a, **kw):
+        raise PermissionError("cannot read")
+
+    monkeypatch.setattr(_Path, "open", unreadable)
+    with pytest.raises(PermissionError):
+        load_backlog(tmp_path)
+
+    monkeypatch.undo()
+    assert path.read_text() == original
+
+
+def test_load_backlog_binary_garbage(tmp_path):
+    """A crash can leave a file full of NULs, which never reaches the parser."""
+    path = tmp_path / "config" / "backlog.json"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"\x00\x81\xfe" * 100)
+    assert load_backlog(tmp_path) == []
+
+
+@pytest.mark.parametrize("payload", ['{"items": null}', "null", '"a string"', "42"])
+def test_load_backlog_non_list_payload(tmp_path, payload):
+    path = tmp_path / "config" / "backlog.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(payload)
+    assert load_backlog(tmp_path) == []

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,8 +1,11 @@
 """Tests for evaluation module."""
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+
+import pytest
 
 from ouroboros.evaluation import (
     EvaluationRecord,
@@ -154,3 +157,90 @@ def test_check_pr_outcomes_updates_success_records(mock_run, _mock_feedback, tmp
 
     persisted = json.loads(history_file.read_text())
     assert persisted[0]["outcome"] == "merged"
+
+
+# -- centralised JSON IO -----------------------------------------------------
+
+def test_history_write_is_atomic(tmp_path, monkeypatch):
+    """A crash mid-write must not leave a truncated history file."""
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "config" / "improvement_history.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("[]")
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+
+    real_replace = os.replace
+    calls = []
+
+    def failing_replace(src, dst):
+        calls.append((src, dst))
+        raise OSError("simulated crash before rename")
+
+    monkeypatch.setattr("ouroboros.storage.os.replace", failing_replace)
+
+    with pytest.raises(OSError):
+        ev.save_json_file(path, [{"a": 1}])
+
+    # The original file is untouched -- the partial write went to a temp file.
+    assert path.read_text() == "[]"
+    assert calls, "expected an atomic rename to have been attempted"
+    monkeypatch.setattr("ouroboros.storage.os.replace", real_replace)
+
+
+def test_load_history_tolerates_a_corrupt_file(tmp_path, monkeypatch):
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_text("{ not json")
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+
+    assert ev.load_history() == []
+
+
+def test_load_history_missing_file_is_empty(tmp_path, monkeypatch):
+    import ouroboros.evaluation as ev
+
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: tmp_path / "nope.json")
+    assert ev.load_history() == []
+
+
+def test_unreadable_history_is_not_silently_replaced(tmp_path, monkeypatch):
+    """An I/O failure must not let record_improvement overwrite real history."""
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_text(json.dumps([{"task_type": "fix_bug"}]))
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+
+    original = path.read_text()
+
+    def unreadable(*a, **kw):
+        raise PermissionError("cannot read")
+
+    monkeypatch.setattr(Path, "open", unreadable)
+
+    with pytest.raises(PermissionError):
+        ev.load_history()
+
+    monkeypatch.undo()
+    assert path.read_text() == original
+
+
+@pytest.mark.parametrize("payload", ["{}", "null", '"a string"', "42"])
+def test_load_history_non_list_payload(tmp_path, monkeypatch, payload):
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_text(payload)
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+    assert ev.load_history() == []
+
+
+def test_load_history_binary_garbage(tmp_path, monkeypatch):
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_bytes(b"\x00\x81\xfe" * 100)
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+    assert ev.load_history() == []

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -191,8 +191,12 @@ def test_load_runner_config_missing_file():
     assert cfg == RunnerConfig()
 
 
-def test_load_state_default():
-    with mock.patch("ouroboros.moltbook.os.path.exists", return_value=False):
+def test_load_state_default(tmp_path):
+    # Point at a path that really is absent rather than mocking os.path.exists:
+    # load_state no longer preflights, so the mock would not apply and the test
+    # would read whatever real state.json the host happens to have.
+    missing = tmp_path / "state.json"
+    with mock.patch("ouroboros.moltbook._state_path", return_value=str(missing)):
         state = load_state()
     assert state["last_check"] is None
     assert state["last_comment_time"] is None
@@ -426,3 +430,28 @@ def test_load_runner_config_null_reviewer_fields_are_empty(tmp_path, value):
 def test_runner_config_repr_hides_the_reviewer_api_key():
     cfg = RunnerConfig(reviewer_api_key="super-secret")
     assert "super-secret" not in repr(cfg)
+
+
+def test_load_state_unreadable_does_not_reset_to_default(tmp_path):
+    """A stat/read error must not look like a fresh install.
+
+    run_loop persists what it loaded, so returning defaults here would
+    overwrite seen_post_ids and the cycle timestamps and the agent would
+    repeat work it had already done.
+    """
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"last_check": 123, "seen_post_ids": ["a"]}))
+
+    real_open = Path.open
+
+    def unreadable(self, *a, **kw):
+        if str(self) == str(state_file):
+            raise PermissionError("EACCES")
+        return real_open(self, *a, **kw)
+
+    with mock.patch("ouroboros.moltbook._state_path", return_value=str(state_file)):
+        with mock.patch.object(Path, "open", unreadable):
+            with pytest.raises(PermissionError):
+                load_state()
+
+    assert json.loads(state_file.read_text())["seen_post_ids"] == ["a"]


### PR DESCRIPTION
Closes #34.

## Why this isn't just tidiness

`evaluation` wrote `improvement_history.json` with a plain `open(..., "w")` in two places. A crash or a full disk mid-write truncates the file **in place**, and the next `load_history` returns nothing — the agent's entire record of what it has tried. `save_json_file` writes a locked temp file, fsyncs, and renames over the target, so a failure leaves the previous contents intact.

`backlog` already did tmp-then-replace, but without the lock or the fsync.

## What routing through the helper exposed

Three ways `load_json_file` could mishandle a file that exists and has data. All of them matter because **every caller here is load-modify-write** — a wrong result isn't a failed read, it's the next save overwriting real state, destroying exactly the data this change set out to protect.

| flaw | effect |
|---|---|
| caught `OSError` and returned the default | EACCES → `record_improvement` gets empty history → atomically writes over the real one |
| probed with `exists()` first | `Path.exists()` is `False` for *any* stat error, so EACCES/EIO read as "missing" regardless of the exception handling |
| caught `JSONDecodeError` but not `UnicodeDecodeError` | a file zeroed by a crash never reaches the JSON parser, so it escaped the corrupt-file path entirely |

Now: the file is opened directly, only `FileNotFoundError` **from the open** counts as absent (which also covers losing a race with a delete), and everything else propagates.

Verified:
```
EACCES now propagates: EACCES
missing file still gives default: {'d': 1}
corrupt file still gives default: {'d': 1}
```

## moltbook.load_state

Had the same `os.path.exists()` preflight, and it's the worst place for it: `run_loop` persists what it loaded, so a transient stat error would write default state over `seen_post_ids` and the cycle timestamps — and the agent repeats work it already did, including posting. Removed.

That change made `test_load_state_default` host-dependent: it mocked `os.path.exists`, which no longer applies, so it would pass on a machine without `~/.config/moltbook/state.json` and read **real state** on one with it — such as the Pi. It now points `_state_path` at a genuinely absent file. Confirmed by planting a real `state.json` and re-running.

## Shape validation

Both loaders now reject valid-JSON-of-the-wrong-shape: `{"items": null}` made `load_backlog` return `None` against its `List[...]` annotation, and a history file of `{}` made `load_history` iterate dict keys and raise from `from_dict`.

## Verification

`528 passed` locally, 3.10–3.14 in CI. Behaviour is otherwise unchanged, including `load_backlog` still accepting a bare list from older files.

## Review

Codex and Antigravity, three rounds. Codex found the `OSError` regression I introduced, then that the `exists()` preflight defeated the fix, then that `moltbook.load_state` bypassed it independently — each verified and fixed; Codex approves. Antigravity added the `UnicodeDecodeError` gap and both wrong-shape cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm