### PR TITLE
test(git_ops): cover the PR query helpers, and stop them failing open

### DIFF
--- a/src/ouroboros/cli.py
+++ b/src/ouroboros/cli.py
@@ -158,7 +158,10 @@ def cmd_improve_status(_args: argparse.Namespace) -> int:
     scheduler_state = load_scheduler_state()
 
     has_open = git_ops.has_open_improvement_prs(repo)
-    print(f"Open improvement PRs: {'yes' if has_open else 'no'}")
+    # Three states, not two: None means gh could not answer, and reporting
+    # that as "no" hides the degraded dependency this contract exists to show.
+    open_prs = "unknown" if has_open is None else ("yes" if has_open else "no")
+    print(f"Open improvement PRs: {open_prs}")
     print(f"Last scheduler status: {scheduler_state.get('last_status') or 'none'}")
     if scheduler_state.get("next_due_ts"):
         next_due = int(scheduler_state["next_due_ts"])

--- a/src/ouroboros/community_improvement.py
+++ b/src/ouroboros/community_improvement.py
@@ -63,7 +63,9 @@ def step_community_improvement(
 
         # Check no open PRs
         repo_root = get_repo_root()
-        if git_ops.has_open_improvement_prs(repo_root):
+        # `is not False` covers None: an indeterminate lookup must not be read
+        # as permission to start work that ends in a PR.
+        if git_ops.has_open_improvement_prs(repo_root) is not False:
             log.debug("[community] Skipping: open improvement PRs exist")
             return None
 

--- a/src/ouroboros/evaluation.py
+++ b/src/ouroboros/evaluation.py
@@ -156,8 +156,20 @@ def check_pr_outcomes(repo_root: Optional[Path] = None) -> List[EvaluationRecord
             )
             state = result.stdout.strip()
             if state in ("MERGED", "CLOSED"):
+                feedback = git_ops.get_pr_feedback(root, record.pr_url)
+                if feedback is None:
+                    # Marking the record terminal now would stop it ever being
+                    # polled again, permanently losing the review text. Leave
+                    # it open and pick it up on the next pass.
+                    log.info(
+                        "PR %s is %s but its feedback could not be fetched; "
+                        "leaving it open to retry",
+                        record.pr_url,
+                        state.lower(),
+                    )
+                    continue
                 record.outcome = state.lower()
-                record.feedback = git_ops.get_pr_feedback(root, record.pr_url)
+                record.feedback = feedback
                 updated = True
                 log.info("PR %s outcome updated: %s", record.pr_url, record.outcome)
         except Exception:

--- a/src/ouroboros/git_ops.py
+++ b/src/ouroboros/git_ops.py
@@ -333,12 +333,26 @@ def make_auto_issue_marker(task_type: str, description: str, target_files: List[
     return f"<!-- ouroboros:auto-issue:{digest} -->"
 
 
-def has_open_improvement_prs(repo: Path) -> bool:
-    """Check if there are any open PRs with the ouroboros/improve- prefix."""
+# gh pr list defaults to 30 results. This guard has to see every open
+# improvement PR, not the first page of them.
+_PR_LIST_LIMIT = 200
+
+
+def has_open_improvement_prs(repo: Path) -> Optional[bool]:
+    """Whether an open ouroboros/improve- PR exists.
+
+    Returns True if one exists, False if none does, and None if that could not
+    be determined -- gh missing, erroring, or hanging.
+
+    None rather than False for the failure case: this gates whether another
+    autonomous cycle may start, and callers read a plain False as permission.
+    A GitHub outage would then let the agent open a second PR for work already
+    in flight, which is the exact situation the guard exists to prevent.
+    """
     try:
         result = subprocess.run(
-            ["gh", "pr", "list", "--state", "open", "--json", "headRefName", "-q",
-             '.[].headRefName'],
+            ["gh", "pr", "list", "--state", "open", "--limit", str(_PR_LIST_LIMIT),
+             "--json", "headRefName", "-q", '.[].headRefName'],
             cwd=repo,
             capture_output=True,
             text=True,
@@ -346,10 +360,20 @@ def has_open_improvement_prs(repo: Path) -> bool:
             timeout=30,
         )
         branches = result.stdout.strip().splitlines()
-        return any(b.startswith("ouroboros/improve-") for b in branches)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        log.warning("Could not check open PRs (gh CLI unavailable?)")
+        if any(b.startswith("ouroboros/improve-") for b in branches):
+            return True
+        if len(branches) >= _PR_LIST_LIMIT:
+            # The page was full, so there may be more we did not see. "None of
+            # the first 200" is not "none".
+            log.warning(
+                "Open PR list hit the %d result limit; cannot rule out an "
+                "open improvement PR", _PR_LIST_LIMIT,
+            )
+            return None
         return False
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        log.warning("Could not check open PRs (gh CLI unavailable or timed out)")
+        return None
 
 
 def make_branch_name(task_type: str) -> str:
@@ -370,7 +394,7 @@ def get_pr_status(repo: Path, branch: str) -> Optional[str]:
             timeout=30,
         )
         return result.stdout.strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
         return None
 
 
@@ -432,12 +456,18 @@ def get_pr_checks_status(repo: Path, pr_url: str) -> Optional[str]:
             timeout=30,
         )
         return result.stdout.strip() or None
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
         return None
 
 
-def get_pr_feedback(repo: Path, pr_url: str, max_chars: int = 2000) -> str:
-    """Extract review and comment bodies from a PR. Returns concatenated text, truncated."""
+def get_pr_feedback(repo: Path, pr_url: str, max_chars: int = 2000) -> Optional[str]:
+    """Extract review and comment bodies from a PR, truncated.
+
+    Returns "" when the PR genuinely has no feedback, and None when it could
+    not be fetched. The caller records this against a terminal outcome and
+    then stops polling that record, so collapsing a timeout into "" would
+    discard the review permanently.
+    """
     try:
         result = subprocess.run(
             [
@@ -455,6 +485,6 @@ def get_pr_feedback(repo: Path, pr_url: str, max_chars: int = 2000) -> str:
         if len(text) > max_chars:
             text = text[:max_chars]
         return text
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
         log.debug("Could not fetch PR feedback for %s", pr_url)
-        return ""
+        return None

--- a/src/ouroboros/github_improvement.py
+++ b/src/ouroboros/github_improvement.py
@@ -227,7 +227,9 @@ def run_github_improvement_cycle(
         log.info("Processing issue #%d: %s", issue.id, issue.title)
         
         # Skip if already has an open improvement PR
-        if git_ops.has_open_improvement_prs(repo_root):
+        # `is not False` covers None: an indeterminate lookup must not be read
+        # as permission to open another PR.
+        if git_ops.has_open_improvement_prs(repo_root) is not False:
             log.info("Skipping issue #%d: another improvement PR is open", issue.id)
             results.append(IssueResolutionResult(issue.id, "skipped", description="Other PR open"))
             continue

--- a/src/ouroboros/improvement.py
+++ b/src/ouroboros/improvement.py
@@ -683,9 +683,16 @@ def run_improvement_cycle(
         return None
 
     # Check for open PRs
-    if git_ops.has_open_improvement_prs(repo_root):
-        log.info("Skipping improvement: open improvement PRs exist")
-        _fire("cycle_end", "Skipped: open improvement PRs exist")
+    open_prs = git_ops.has_open_improvement_prs(repo_root)
+    if open_prs is not False:
+        # None means the lookup failed; defer rather than risk a second PR for
+        # work already in flight.
+        reason = (
+            "open improvement PRs exist" if open_prs
+            else "could not determine whether an improvement PR is open"
+        )
+        log.info("Skipping improvement: %s", reason)
+        _fire("cycle_end", f"Skipped: {reason}")
         return None
 
     # Dedup: skip if recent attempts at the same task_type made no test progress

--- a/src/ouroboros/improvement_runner.py
+++ b/src/ouroboros/improvement_runner.py
@@ -249,12 +249,19 @@ def run_scheduled_self_improvement(
         return ScheduledImprovementRun("skipped_dirty_repo", state["last_error"])
 
     check_pr_outcomes(repo_root)
-    if git_ops.has_open_improvement_prs(repo_root):
+    open_prs = git_ops.has_open_improvement_prs(repo_root)
+    if open_prs is not False:
+        # None means the lookup failed; defer rather than risk a second PR for
+        # work already in flight.
         _set_deferred_state(
             state,
             now,
             "skipped_open_pr",
-            "Open autonomous improvement PR already exists.",
+            (
+                "Open autonomous improvement PR already exists."
+                if open_prs
+                else "Could not determine whether an improvement PR is open."
+            ),
             OPEN_PR_RETRY_SECONDS,
         )
         save_scheduler_state(state)

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -1256,7 +1256,7 @@ def run_loop() -> int:
                         check_pr_outcomes(repo_root)
 
                         # Skip if open PRs exist
-                        if not _git_ops.has_open_improvement_prs(repo_root):
+                        if _git_ops.has_open_improvement_prs(repo_root) is False:
                             log.info("[self-improve] Starting improvement cycle...")
                             imp_result = run_improvement_cycle(
                                 _pick_client(cfg.improvement_model), state, safety,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
+import pytest
 import argparse
 import json
 from unittest.mock import MagicMock, patch
 from ouroboros.cli import (
+    cmd_improve_status,
     cmd_plan,
     cmd_config_show,
     cmd_config_modify,
@@ -90,3 +92,23 @@ def test_cmd_improve_scout_success(mock_scout, mock_repo_root, _mock_key, _mock_
     captured = capsys.readouterr()
     assert "Issue scout: [created] Opened issue" in captured.out
     assert "Issue: https://github.com/repo/issues/42" in captured.out
+
+
+@pytest.mark.parametrize(
+    ("lookup", "expected"),
+    [(True, "yes"), (False, "no"), (None, "unknown")],
+)
+@patch("ouroboros.moltbook.load_state", return_value={})
+@patch("ouroboros.improvement_runner.load_scheduler_state", return_value={})
+@patch("ouroboros.evaluation.check_pr_outcomes", return_value=[])
+@patch("ouroboros.codebase.get_repo_root", return_value="/repo")
+@patch("ouroboros.git_ops.has_open_improvement_prs")
+def test_status_reports_the_open_pr_state_in_three_forms(
+    mock_has_open, _root, _outcomes, _sched, _loop, lookup, expected, capsys
+):
+    """Reporting an indeterminate lookup as "no" hides a degraded dependency."""
+    mock_has_open.return_value = lookup
+
+    cmd_improve_status(argparse.Namespace())
+
+    assert f"Open improvement PRs: {expected}" in capsys.readouterr().out

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -244,3 +244,62 @@ def test_load_history_binary_garbage(tmp_path, monkeypatch):
     path.write_bytes(b"\x00\x81\xfe" * 100)
     monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
     assert ev.load_history() == []
+
+
+def test_unfetchable_feedback_leaves_the_record_open(tmp_path, monkeypatch):
+    """A terminal record is never polled again, so it must not be finalised
+    before its review text has actually been retrieved."""
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_text(json.dumps([{
+        "task_id": "abc", "task_type": "fix_bug", "description": "d",
+        "test_delta": {}, "pr_url": "https://github.com/x/pull/1",
+        "outcome": "success", "feedback": "", "timestamp": 1000.0,
+    }]))
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+
+    with patch("subprocess.run", return_value=MagicMock(stdout="MERGED\n")):
+        with patch.object(ev.git_ops, "get_pr_feedback", return_value=None):
+            history = ev.check_pr_outcomes(tmp_path)
+
+    assert history[0].outcome == "success", "must stay pollable"
+    assert json.loads(path.read_text())[0]["outcome"] == "success"
+
+
+def test_fetched_feedback_finalises_the_record(tmp_path, monkeypatch):
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_text(json.dumps([{
+        "task_id": "abc", "task_type": "fix_bug", "description": "d",
+        "test_delta": {}, "pr_url": "https://github.com/x/pull/1",
+        "outcome": "success", "feedback": "", "timestamp": 1000.0,
+    }]))
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+
+    with patch("subprocess.run", return_value=MagicMock(stdout="MERGED\n")):
+        with patch.object(ev.git_ops, "get_pr_feedback", return_value="Nice work"):
+            history = ev.check_pr_outcomes(tmp_path)
+
+    assert history[0].outcome == "merged"
+    assert history[0].feedback == "Nice work"
+
+
+def test_a_merged_pr_with_genuinely_no_feedback_still_finalises(tmp_path, monkeypatch):
+    """"" is a real answer; only None means the fetch failed."""
+    import ouroboros.evaluation as ev
+
+    path = tmp_path / "improvement_history.json"
+    path.write_text(json.dumps([{
+        "task_id": "abc", "task_type": "fix_bug", "description": "d",
+        "test_delta": {}, "pr_url": "https://github.com/x/pull/1",
+        "outcome": "success", "feedback": "", "timestamp": 1000.0,
+    }]))
+    monkeypatch.setattr(ev, "_history_path", lambda root=None: path)
+
+    with patch("subprocess.run", return_value=MagicMock(stdout="MERGED\n")):
+        with patch.object(ev.git_ops, "get_pr_feedback", return_value=""):
+            history = ev.check_pr_outcomes(tmp_path)
+
+    assert history[0].outcome == "merged"

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,5 +1,6 @@
 """Tests for git_ops module."""
 
+import subprocess
 import time
 from unittest.mock import patch, MagicMock
 
@@ -8,6 +9,9 @@ from pathlib import Path
 
 from ouroboros.git_ops import (
     _decode_git_path,
+    get_pr_feedback,
+    get_pr_status,
+    has_open_improvement_prs,
     _is_auto_state_path,
     _git_porcelain_changes,
     _git_porcelain_target_path,
@@ -301,3 +305,259 @@ def test_commit_auto_state_ignores_sibling_of_state_file(mock_git, mock_branch):
 
     assert commit_auto_state(Path("/tmp/repo")) is False
     assert mock_git.call_count == 1  # never reached git add
+
+
+# -- has_open_improvement_prs ------------------------------------------------
+
+def _completed(stdout="", returncode=0):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_true(mock_run):
+    mock_run.return_value = _completed("ouroboros/improve-fix_bug-123\nfeature/other\n")
+    assert has_open_improvement_prs(Path("/repo")) is True
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_ignores_other_branches(mock_run):
+    """Only the agent's own branches gate the next cycle."""
+    mock_run.return_value = _completed("feature/x\nbugfix/y\nouroboros/other-thing\n")
+    assert has_open_improvement_prs(Path("/repo")) is False
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_no_open_prs(mock_run):
+    mock_run.return_value = _completed("")
+    assert has_open_improvement_prs(Path("/repo")) is False
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_whitespace_only(mock_run):
+    mock_run.return_value = _completed("\n  \n")
+    assert has_open_improvement_prs(Path("/repo")) is False
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_queries_open_only(mock_run):
+    mock_run.return_value = _completed("")
+    has_open_improvement_prs(Path("/repo"))
+
+    cmd = mock_run.call_args.args[0]
+    kwargs = mock_run.call_args.kwargs
+    assert cmd[:3] == ["gh", "pr", "list"]
+    assert "--state" in cmd and cmd[cmd.index("--state") + 1] == "open"
+    # gh pr list defaults to 30; the guard has to see every open PR, not a page.
+    assert "--limit" in cmd and int(cmd[cmd.index("--limit") + 1]) >= 100
+    assert kwargs["cwd"] == Path("/repo")
+    assert kwargs["check"] is True
+    assert kwargs["text"] is True
+    assert kwargs["timeout"] == 30
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_sees_beyond_the_first_page(mock_run):
+    """A matching PR after the default 30 must still be found."""
+    branches = [f"feature/pr-{i}" for i in range(40)]
+    branches.append("ouroboros/improve-fix_bug-999")
+    mock_run.return_value = _completed("\n".join(branches))
+
+    assert has_open_improvement_prs(Path("/repo")) is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        subprocess.CalledProcessError(1, ["gh"]),
+        FileNotFoundError("gh not installed"),
+        subprocess.TimeoutExpired(["gh"], 30),
+    ],
+)
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_unknown_on_gh_failure(mock_run, error):
+    """Unknown must not read as "none".
+
+    This gates whether another cycle may start, and callers treat False as
+    permission -- so a GitHub outage returning False would let the agent open
+    a second PR for work already in flight.
+    """
+    mock_run.side_effect = error
+    assert has_open_improvement_prs(Path("/repo")) is None
+
+
+# -- get_pr_status -----------------------------------------------------------
+
+@pytest.mark.parametrize("state", ["MERGED", "CLOSED", "OPEN"])
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_status_returns_the_state(mock_run, state):
+    mock_run.return_value = _completed(f"{state}\n")
+    assert get_pr_status(Path("/repo"), "some-branch") == state
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_status_passes_the_branch(mock_run):
+    mock_run.return_value = _completed("OPEN")
+    get_pr_status(Path("/repo"), "ouroboros/improve-fix_bug-1")
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[:3] == ["gh", "pr", "view"]
+    assert "ouroboros/improve-fix_bug-1" in cmd
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_status_empty_output(mock_run):
+    mock_run.return_value = _completed("")
+    assert get_pr_status(Path("/repo"), "branch") == ""
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        subprocess.CalledProcessError(1, ["gh"]),   # no PR for this branch
+        FileNotFoundError("gh not installed"),
+        subprocess.TimeoutExpired(["gh"], 30),
+    ],
+)
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_status_none_on_failure(mock_run, error):
+    mock_run.side_effect = error
+    assert get_pr_status(Path("/repo"), "branch") is None
+
+
+# -- get_pr_feedback ---------------------------------------------------------
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_feedback_returns_review_text(mock_run):
+    mock_run.return_value = _completed("Looks good\n---\nOne nit\n")
+    assert get_pr_feedback(Path("/repo"), "https://x/pr/1") == "Looks good\n---\nOne nit"
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_feedback_requests_reviews_and_comments(mock_run):
+    mock_run.return_value = _completed("")
+    get_pr_feedback(Path("/repo"), "https://x/pr/1")
+
+    cmd = mock_run.call_args.args[0]
+    assert "--json" in cmd
+    assert cmd[cmd.index("--json") + 1] == "reviews,comments"
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_feedback_truncates(mock_run):
+    """This text is fed back into a prompt, so it needs a ceiling."""
+    mock_run.return_value = _completed("x" * 5000)
+    assert len(get_pr_feedback(Path("/repo"), "https://x/pr/1", max_chars=100)) == 100
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_feedback_under_the_limit_is_untouched(mock_run):
+    mock_run.return_value = _completed("short")
+    assert get_pr_feedback(Path("/repo"), "https://x/pr/1", max_chars=100) == "short"
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_feedback_empty(mock_run):
+    mock_run.return_value = _completed("   \n")
+    # "" means the query worked and there was nothing to report.
+    assert get_pr_feedback(Path("/repo"), "https://x/pr/1") == ""
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        subprocess.CalledProcessError(1, ["gh"]),
+        FileNotFoundError("gh not installed"),
+        subprocess.TimeoutExpired(["gh"], 30),
+    ],
+)
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_feedback_none_on_failure(mock_run, error):
+    """None, not "": the caller finalises the record and stops polling it, so
+    an unfetchable review would otherwise be lost permanently."""
+    mock_run.side_effect = error
+    assert get_pr_feedback(Path("/repo"), "https://x/pr/1") is None
+
+
+def test_every_open_pr_caller_handles_the_unknown_state():
+    """The tri-state contract only helps if every call site honours it.
+
+    Two ways to get it wrong: branching directly on the call, or assigning it
+    and never distinguishing None from False. The CLI did the second, which an
+    `if <call>` check misses.
+
+    Truthiness *after* an explicit comparison is fine -- at that point the
+    ambiguous case has already been separated out -- so this requires an
+    explicit `is`/`is not` comparison per name rather than forbidding all
+    boolean use.
+    """
+    import ast
+    from pathlib import Path as _Path
+
+    CALL = "has_open_improvement_prs"
+    src = _Path(__file__).resolve().parent.parent / "src" / "ouroboros"
+    offenders = []
+
+    def _is_the_call(node):
+        return (
+            isinstance(node, ast.Call)
+            and getattr(node.func, "attr", getattr(node.func, "id", None)) == CALL
+        )
+
+    for path in sorted(src.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if CALL not in text or path.name == "git_ops.py":
+            continue
+        tree = ast.parse(text)
+
+        for node in ast.walk(tree):
+            # Branching straight on the call cannot distinguish None.
+            if isinstance(node, (ast.If, ast.IfExp)):
+                test = node.test
+                if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+                    test = test.operand
+                if _is_the_call(test):
+                    offenders.append(f"{path.name}:{node.lineno} (bare call)")
+
+        # Every name the result is bound to must be compared explicitly.
+        bound = {
+            target.id: node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign) and _is_the_call(node.value)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        compared = {
+            operand.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Compare)
+            and any(isinstance(op, (ast.Is, ast.IsNot)) for op in node.ops)
+            for operand in [node.left]
+            if isinstance(operand, ast.Name)
+        }
+        for name, lineno in bound.items():
+            if name not in compared:
+                offenders.append(f"{path.name}:{lineno} ({name} never compared)")
+
+    assert offenders == [], (
+        "these read the result as a boolean, so None counts as "
+        f"'no open PR': {', '.join(offenders)}"
+    )
+
+
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_saturated_page_is_unknown(mock_run):
+    """"None of the first 200" is not "none"."""
+    from ouroboros.git_ops import _PR_LIST_LIMIT
+
+    mock_run.return_value = _completed(
+        "\n".join(f"feature/pr-{i}" for i in range(_PR_LIST_LIMIT))
+    )
+    assert has_open_improvement_prs(Path("/repo")) is None
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_has_open_improvement_prs_short_page_is_definitive(mock_run):
+    mock_run.return_value = _completed("\n".join(f"feature/pr-{i}" for i in range(5)))
+    assert has_open_improvement_prs(Path("/repo")) is False

--- a/tests/test_improvement_runner.py
+++ b/tests/test_improvement_runner.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock, patch
 
 from ouroboros.improvement import ImprovementResult, ImprovementTask
@@ -115,3 +116,49 @@ def test_run_scheduled_self_improvement_skips_until_due(mock_cfg, _mock_load_sta
     result = run_scheduled_self_improvement()
 
     assert result.status == "skipped_due"
+
+
+@pytest.mark.parametrize(
+    ("open_pr_lookup", "expected_status"),
+    [
+        (True, "skipped_open_pr"),
+        # None means gh could not answer. Treating that as "no open PR" would
+        # let the agent open a second PR for work already in flight.
+        (None, "skipped_open_pr"),
+    ],
+)
+@patch("ouroboros.improvement_runner.time.time", return_value=1_700_000_000)
+@patch("ouroboros.improvement_runner.save_scheduler_state")
+@patch("ouroboros.improvement_runner.load_scheduler_state",
+       # A fresh dict per call: the runner mutates the state it is handed, so a
+       # shared return_value leaks next_due_ts into the next parametrised case.
+       side_effect=lambda: {"consecutive_failures": 0, "next_due_ts": None})
+@patch("ouroboros.improvement_runner._load_feed_context_state", return_value={})
+@patch("ouroboros.improvement_runner.run_improvement_cycle")
+@patch("ouroboros.improvement_runner.git_ops.has_open_improvement_prs")
+@patch("ouroboros.improvement_runner.git_ops.is_clean", return_value=True)
+@patch("ouroboros.improvement_runner.check_pr_outcomes")
+@patch("ouroboros.improvement_runner.get_repo_root")
+@patch("ouroboros.improvement_runner.load_runner_config")
+def test_scheduled_run_defers_unless_open_pr_state_is_definitely_false(
+    mock_cfg,
+    mock_repo_root,
+    _mock_check_prs,
+    _mock_is_clean,
+    mock_has_open_prs,
+    mock_run_cycle,
+    _mock_feed_state,
+    _mock_load_state,
+    _mock_save_state,
+    _mock_time,
+    open_pr_lookup,
+    expected_status,
+):
+    mock_cfg.return_value = _cfg()
+    mock_repo_root.return_value = "/tmp/repo"
+    mock_has_open_prs.return_value = open_pr_lookup
+
+    result = run_scheduled_self_improvement()
+
+    assert result.status == expected_status
+    mock_run_cycle.assert_not_called()


### PR DESCRIPTION
Closes #38.

`has_open_improvement_prs`, `get_pr_status` and `get_pr_feedback` had no tests. `git_ops.py` sat at 37%, and all three shell out to `gh` on paths the unattended loop depends on.

**37 tests. git_ops.py 37% → 69%.**

## Five real problems the tests surfaced

**1. Timeouts weren't caught.** All three pass `timeout=30` to `subprocess.run` but caught only `CalledProcessError` and `FileNotFoundError`, so a hung `gh` raised `TimeoutExpired` straight through — defeating the point of setting a timeout. `auto_merge_pr`, in the same file, already caught it.

**2. …and adding that catch made it worse.** Returning `False` on failure tells the caller "no open PR", and callers read that as *permission to start a cycle*. A GitHub outage would let the agent open a second PR for work already in flight — the exact situation the guard exists to prevent. Before the catch, the exception at least aborted the cycle.

Now `Optional[bool]`, with `None` = "could not determine". **All six call sites** treat `None` as "do not start": `improvement`, `improvement_runner`, `github_improvement`, `community_improvement`, the moltbook loop, and the CLI status line — which now prints `unknown` rather than claiming `no`.

**3. No `--limit`.** `gh pr list` defaults to 30, so an improvement PR past the first page made the guard report none and start duplicate work. Bounded at 200 — and **a full page returns `None`, not `False`**, because "none of the first 200" is not "none".

**4. `get_pr_feedback` conflated "no feedback" with "couldn't fetch".** `check_pr_outcomes` writes that against a terminal outcome and then never polls the record again, so a transient timeout discarded the review *permanently* — and collapsing `TimeoutExpired` into that path was new in this PR. Now `Optional[str]`, and `check_pr_outcomes` leaves the record open to retry instead of finalising it empty.

## Regression guard

A test walks the AST of every module and fails on **both** ways to get the tri-state wrong: branching directly on the call, and binding the result to a name that is never compared with `is`/`is not`. The CLI's bug was the second form, which an `if <call>` check misses.

Truthiness *after* an explicit comparison is allowed — the ambiguous case is already separated by then, so the inner ternaries that pick a log message aren't flagged. Confirmed to fail when either call site is reverted:

```
github_improvement.py  -> FAILS (good)
cli.py                 -> FAILS (good)
```

## Verification

`633 passed` locally, 3.10–3.14 in CI. The caller-level deferral is tested through the real `run_scheduled_self_improvement`, confirmed to fail against the old `if open_prs:`.

## Review

Codex and Antigravity, four rounds. Both flagged that catching `TimeoutExpired` made the guard fail open — the central finding, and one I introduced. Codex then found I'd migrated only 2 of 4 callers, the `--limit` pagination gap, the saturation case, that the CLI still collapsed `None` to "no", and that my first AST guard missed the `IfExp`-on-a-variable form. Each verified and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm