### PR TITLE
test(backlog): cover organize_backlog, and stop model output corrupting it

### DIFF
--- a/src/ouroboros/backlog.py
+++ b/src/ouroboros/backlog.py
@@ -108,15 +108,52 @@ def format_backlog_for_llm(items: List[Dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+def _valid_organizer_fields(entry: Dict[str, Any]) -> bool:
+    """Check the field values an organizer entry may set.
+
+    A null or wrongly typed value here is written straight into the queue: a
+    null priority makes get_pending raise while sorting, and a blank
+    description leaves a task nobody can act on.
+    """
+    task_type = entry.get("type")
+    if task_type is not None and (not isinstance(task_type, str) or not task_type.strip()):
+        return False
+
+    desc = entry.get("desc")
+    if desc is not None and not isinstance(desc, str):
+        return False
+
+    priority = entry.get("priority")
+    if priority is not None:
+        if isinstance(priority, bool) or not isinstance(priority, int):
+            return False
+        if not 1 <= priority <= 10:
+            return False
+
+    return True
+
+
 def organize_backlog(repo_root: Path, client: Any, model: str = DEFAULT_OPENAI_MODEL) -> None:
     """Use an LLM to prune, merge, and prioritize the backlog."""
     items = load_backlog(repo_root)
-    if not items:
+    pending = [i for i in items if i.get("status") == "pending"]
+    if not pending:
+        # Returning only when `items` is empty still sent "[]" to the model
+        # for a backlog of nothing but done and failed records, and anything
+        # it invented was persisted as new pending work.
         return
 
+    # .get throughout: a hand-edited or legacy record missing a key would
+    # otherwise raise out of this function, which is supposed to log and leave
+    # the backlog alone.
     backlog_text = json.dumps([
-        {"id": i["id"], "type": i["task_type"], "desc": i["description"], "priority": i["priority"]}
-        for i in items if i["status"] == "pending"
+        {
+            "id": i.get("id"),
+            "type": i.get("task_type"),
+            "desc": i.get("description"),
+            "priority": i.get("priority"),
+        }
+        for i in pending
     ], indent=2)
 
     system = (
@@ -130,38 +167,97 @@ def organize_backlog(repo_root: Path, client: Any, model: str = DEFAULT_OPENAI_M
     user = f"Current Pending Backlog:\n{backlog_text}\n\nPlease organize this backlog."
     
     from .llm import chat_completion
-    content, _ = chat_completion(client, system, user, model=model)
-    
+
     try:
+        # Inside the try: this function's contract is to log and leave the
+        # backlog alone on failure. chat_completion happens to swallow its own
+        # errors today, so the call only looked safe out here.
+        content, _ = chat_completion(client, system, user, model=model)
         if "{" in content:
             content = content[content.find("{"):content.rfind("}")+1]
         data = json.loads(content)
-        new_items = data.get("items", [])
-        
-        # Merge new items back with non-pending ones
-        final_items = [i for i in items if i["status"] != "pending"]
+        if not isinstance(data, dict) or not isinstance(data.get("items"), list):
+            log.warning("Backlog organizer returned no usable 'items'; leaving backlog alone")
+            return
+        new_items = data["items"]
+        if not new_items:
+            # Omission is how this protocol expresses pruning, so an empty
+            # list is indistinguishable from a truncated reply -- and it would
+            # delete every pending item. Refuse rather than guess.
+            log.warning("Backlog organizer returned an empty list; leaving backlog alone")
+            return
+
+        # Updates resolve against pending records only. Searching every record
+        # let an invented id collide with a done or failed one, mutating
+        # history in place and appending it twice.
+        pending_by_id = {i["id"]: i for i in pending if i.get("id")}
+        all_ids = {i["id"] for i in items if i.get("id")}
+
+        # Validate the whole response before touching anything, so a single
+        # bad entry cannot leave the backlog half-rewritten.
+        seen_ids = set()
         for ni in new_items:
-            # Check if this was an existing ID
-            existing = [i for i in items if i["id"] == ni.get("id")]
-            if existing:
-                e = existing[0]
-                e["task_type"] = ni.get("type", e["task_type"])
-                e["description"] = ni.get("desc", e["description"])
-                e["priority"] = ni.get("priority", e["priority"])
-                final_items.append(e)
+            if not isinstance(ni, dict):
+                log.warning("Backlog organizer returned a non-object entry; leaving backlog alone")
+                return
+
+            item_id = ni.get("id")
+            if item_id is not None:
+                if item_id in seen_ids:
+                    # mark_done stops at the first match, so a duplicate would
+                    # stay pending and be worked twice.
+                    log.warning("Backlog organizer repeated id %r; leaving backlog alone", item_id)
+                    return
+                seen_ids.add(item_id)
+
+            if item_id not in pending_by_id and not str(ni.get("desc") or "").strip():
+                # Neither an update to something real nor a usable new task.
+                log.warning("Backlog organizer returned an unusable entry (%r); leaving backlog alone", ni)
+                return
+
+            if not _valid_organizer_fields(ni):
+                log.warning("Backlog organizer returned bad field values (%r); leaving backlog alone", ni)
+                return
+
+        final_items = [i for i in items if i.get("status") != "pending"]
+        for ni in new_items:
+            existing = pending_by_id.get(ni.get("id"))
+            if existing is not None:
+                # Only overwrite what the model actually supplied; an explicit
+                # null is an omission, not an instruction to blank the field.
+                for key, field in (("type", "task_type"), ("desc", "description"),
+                                   ("priority", "priority")):
+                    value = ni.get(key)
+                    if value is None:
+                        continue
+                    if isinstance(value, str) and not value.strip():
+                        # A blank string is an omission too. Applying it would
+                        # leave a task with no description, which nobody can
+                        # act on and nothing else can recover.
+                        continue
+                    existing[field] = value
+                final_items.append(existing)
             else:
-                # New "Epic" or merged task
+                # A fresh id when the model's collides with any existing
+                # record, so a new task cannot overwrite history.
+                item_id = ni.get("id")
+                if not item_id or item_id in all_ids:
+                    item_id = str(uuid.uuid4())[:8]
+                all_ids.add(item_id)
                 final_items.append({
-                    "id": ni.get("id") or str(uuid.uuid4())[:8],
-                    "task_type": ni.get("type", "refactor"),
+                    "id": item_id,
+                    "task_type": ni.get("type") or "refactor",
                     "description": ni.get("desc", ""),
-                    "priority": ni.get("priority", 5),
-                    "status": ni.get("status", "pending"),
+                    "priority": ni.get("priority") or 5,
+                    # Never model-controlled: status="done" on a new entry
+                    # would delete the omitted records and leave nothing
+                    # pending to replace them.
+                    "status": "pending",
                     "source": "backlog_organizer",
                     "created_at": time.time(),
-                    "attempts": 0
+                    "attempts": 0,
                 })
-        
+
         save_backlog(repo_root, final_items)
         log.info("Backlog organized semantically.")
     except Exception:

--- a/tests/test_backlog.py
+++ b/tests/test_backlog.py
@@ -6,8 +6,10 @@ import time
 from pathlib import Path
 
 import pytest
+from unittest.mock import patch
 
 from ouroboros.backlog import (
+    organize_backlog,
     load_backlog,
     save_backlog,
     add_item,
@@ -204,3 +206,338 @@ def test_load_backlog_non_list_payload(tmp_path, payload):
     path.parent.mkdir(parents=True)
     path.write_text(payload)
     assert load_backlog(tmp_path) == []
+
+
+# -- organize_backlog --------------------------------------------------------
+
+def _item(item_id, *, task_type="fix_bug", description="d", priority=5,
+          status="pending", **extra):
+    base = {
+        "id": item_id,
+        "task_type": task_type,
+        "description": description,
+        "priority": priority,
+        "status": status,
+        "source": "test",
+        "created_at": 1000.0,
+        "attempts": 0,
+    }
+    base.update(extra)
+    return base
+
+
+def _client_returning(payload):
+    """Patch chat_completion to return payload; organize_backlog imports it late."""
+    return patch("ouroboros.llm.chat_completion", return_value=(payload, None))
+
+
+def test_organize_backlog_no_op_on_empty(tmp_path):
+    with patch("ouroboros.llm.chat_completion") as chat:
+        organize_backlog(tmp_path, client=object())
+    chat.assert_not_called()
+
+
+def test_organize_backlog_updates_an_existing_item(tmp_path):
+    save_backlog(tmp_path, [_item("a1", description="old", priority=5)])
+
+    payload = json.dumps({"items": [
+        {"id": "a1", "type": "refactor", "desc": "new wording", "priority": 9}
+    ]})
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    items = load_backlog(tmp_path)
+    assert len(items) == 1
+    assert items[0]["id"] == "a1"
+    assert items[0]["task_type"] == "refactor"
+    assert items[0]["description"] == "new wording"
+    assert items[0]["priority"] == 9
+    # Untouched bookkeeping survives.
+    assert items[0]["created_at"] == 1000.0
+    assert items[0]["source"] == "test"
+
+
+def test_organize_backlog_keeps_fields_the_model_omitted(tmp_path):
+    save_backlog(tmp_path, [_item("a1", task_type="add_test", description="keep me",
+                                  priority=3)])
+
+    with _client_returning(json.dumps({"items": [{"id": "a1"}]})):
+        organize_backlog(tmp_path, client=object())
+
+    item = load_backlog(tmp_path)[0]
+    assert item["task_type"] == "add_test"
+    assert item["description"] == "keep me"
+    assert item["priority"] == 3
+
+
+def test_organize_backlog_creates_a_merged_epic(tmp_path):
+    """An id the model invented becomes a new item, not an update."""
+    save_backlog(tmp_path, [_item("a1"), _item("b2")])
+
+    payload = json.dumps({"items": [
+        {"id": "epic1", "type": "refactor", "desc": "Merge a1 and b2", "priority": 8}
+    ]})
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    items = load_backlog(tmp_path)
+    assert [i["id"] for i in items] == ["epic1"]
+    assert items[0]["source"] == "backlog_organizer"
+    assert items[0]["status"] == "pending"
+    assert items[0]["attempts"] == 0
+
+
+def test_organize_backlog_drops_pruned_items(tmp_path):
+    """Anything the model leaves out of its reply is pruned."""
+    save_backlog(tmp_path, [_item("a1"), _item("b2"), _item("c3")])
+
+    with _client_returning(json.dumps({"items": [{"id": "a1"}]})):
+        organize_backlog(tmp_path, client=object())
+
+    assert [i["id"] for i in load_backlog(tmp_path)] == ["a1"]
+
+
+def test_organize_backlog_never_touches_non_pending_items(tmp_path):
+    """Done and failed history must survive an organiser that ignores it."""
+    save_backlog(tmp_path, [
+        _item("done1", status="done"),
+        _item("failed1", status="failed"),
+        _item("pending1"),
+    ])
+
+    with _client_returning(json.dumps({"items": [{"id": "pending1"}]})):
+        organize_backlog(tmp_path, client=object())
+
+    ids = {i["id"] for i in load_backlog(tmp_path)}
+    assert ids == {"done1", "failed1", "pending1"}
+
+
+def test_organize_backlog_only_sends_pending_items_to_the_model(tmp_path):
+    save_backlog(tmp_path, [_item("done1", status="done"), _item("p1")])
+
+    with patch("ouroboros.llm.chat_completion",
+               return_value=(json.dumps({"items": [{"id": "p1"}]}), None)) as chat:
+        organize_backlog(tmp_path, client=object())
+
+    prompt = chat.call_args.args[2]
+    assert "p1" in prompt
+    assert "done1" not in prompt
+
+
+def test_organize_backlog_tolerates_prose_around_the_json(tmp_path):
+    save_backlog(tmp_path, [_item("a1", priority=1)])
+
+    payload = 'Sure! Here you go:\n```json\n{"items": [{"id": "a1", "priority": 7}]}\n```\n'
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path)[0]["priority"] == 7
+
+
+@pytest.mark.parametrize("payload", ["", "not json at all", "{broken", "null"])
+def test_organize_backlog_leaves_the_backlog_alone_on_bad_output(tmp_path, payload):
+    """A malformed reply must not destroy the backlog."""
+    original = [_item("a1"), _item("b2")]
+    save_backlog(tmp_path, original)
+
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path) == original
+
+
+def test_organize_backlog_survives_a_model_error(tmp_path):
+    original = [_item("a1")]
+    save_backlog(tmp_path, original)
+
+    with patch("ouroboros.llm.chat_completion", side_effect=RuntimeError("api down")):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path) == original
+
+
+def test_organize_backlog_passes_the_model_through(tmp_path):
+    save_backlog(tmp_path, [_item("a1")])
+
+    with patch("ouroboros.llm.chat_completion",
+               return_value=(json.dumps({"items": [{"id": "a1"}]}), None)) as chat:
+        organize_backlog(tmp_path, client=object(), model="gpt-test")
+
+    assert chat.call_args.kwargs["model"] == "gpt-test"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"items": []}',            # truncated reply is indistinguishable from "delete all"
+        '{"other_key": [1]}',       # valid JSON, wrong shape
+        '{"items": "not a list"}',
+        '[{"id": "a1"}]',           # a bare list, not the documented object
+    ],
+)
+def test_organize_backlog_refuses_to_empty_the_backlog(tmp_path, payload):
+    """Omission is how this protocol prunes, so an empty list cannot be
+    distinguished from a truncated reply -- and acting on it deletes every
+    pending item."""
+    original = [_item("a1"), _item("b2")]
+    save_backlog(tmp_path, original)
+
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path) == original
+
+
+def test_organize_backlog_skips_a_backlog_with_nothing_pending(tmp_path):
+    """A history of done and failed records is not something to organise."""
+    save_backlog(tmp_path, [_item("d1", status="done"), _item("f1", status="failed")])
+
+    with patch("ouroboros.llm.chat_completion") as chat:
+        organize_backlog(tmp_path, client=object())
+
+    chat.assert_not_called()
+    assert {i["id"] for i in load_backlog(tmp_path)} == {"d1", "f1"}
+
+
+def test_organize_backlog_tolerates_a_sparse_record(tmp_path):
+    """A hand-edited or legacy record must not raise out of the organiser."""
+    save_backlog(tmp_path, [{"id": "a1", "status": "pending"}])
+
+    with _client_returning(json.dumps({"items": [{"id": "a1", "priority": 4}]})):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path)[0]["priority"] == 4
+
+
+def test_format_backlog_for_llm_is_empty_without_pending_items():
+    """Nothing pending means nothing to put in the prompt."""
+    from ouroboros.backlog import format_backlog_for_llm
+
+    assert format_backlog_for_llm([_item("d1", status="done")]) == ""
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"items": [{}]}',                        # blank entry
+        '{"items": [{"priority": 3}]}',           # no id, no description
+        '{"items": [{"id": null, "desc": ""}]}',
+        '{"items": ["a string"]}',                # not even an object
+        '{"items": [{"id": "a1"}, {}]}',          # one good, one blank
+    ],
+)
+def test_organize_backlog_rejects_unusable_entries(tmp_path, payload):
+    """{"items": [{}]} passed the emptiness check and replaced the whole
+    pending backlog with one blank task."""
+    original = [_item("a1"), _item("b2")]
+    save_backlog(tmp_path, original)
+
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path) == original
+
+
+def test_organize_backlog_tolerates_a_record_without_status(tmp_path):
+    save_backlog(tmp_path, [{"id": "a1", "description": "d", "priority": 5}])
+
+    with _client_returning(json.dumps({"items": [{"id": "n1", "desc": "new"}]})):
+        organize_backlog(tmp_path, client=object())
+
+    # No pending records at all, so there was nothing to organise.
+    assert [i["id"] for i in load_backlog(tmp_path)] == ["a1"]
+
+
+def test_organize_backlog_tolerates_a_record_without_an_id(tmp_path):
+    """A record with no id must not be merged into by an entry with no id."""
+    save_backlog(tmp_path, [{"status": "pending", "description": "keep", "priority": 5}])
+
+    with _client_returning(json.dumps({"items": [{"desc": "brand new"}]})):
+        organize_backlog(tmp_path, client=object())
+
+    items = load_backlog(tmp_path)
+    assert len(items) == 1
+    assert items[0]["description"] == "brand new"
+    assert items[0]["source"] == "backlog_organizer"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Explicit nulls must not blank fields on an existing item.
+        '{"items": [{"id": "a1", "type": null, "desc": "", "priority": null}]}',
+        '{"items": [{"id": "a1", "priority": 0}]}',      # out of range
+        '{"items": [{"id": "a1", "priority": 11}]}',
+        '{"items": [{"id": "a1", "priority": "high"}]}',  # wrong type
+        '{"items": [{"id": "a1", "type": 42}]}',
+        '{"items": [{"id": "a1", "desc": 42}]}',
+    ],
+)
+def test_organize_backlog_rejects_bad_field_values(tmp_path, payload):
+    """A null priority makes get_pending raise while sorting."""
+    original = [_item("a1", description="keep", priority=5)]
+    save_backlog(tmp_path, original)
+
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path) == original
+
+
+def test_organize_backlog_rejects_duplicate_ids(tmp_path):
+    """mark_done stops at the first match, so a duplicate stays pending and
+    gets worked twice."""
+    original = [_item("a1"), _item("b2")]
+    save_backlog(tmp_path, original)
+
+    payload = json.dumps({"items": [{"id": "a1"}, {"id": "a1", "priority": 9}]})
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    assert load_backlog(tmp_path) == original
+
+
+def test_organize_backlog_will_not_let_a_new_item_declare_itself_done(tmp_path):
+    """status="done" would delete the omitted records and leave nothing
+    pending to replace them."""
+    save_backlog(tmp_path, [_item("a1")])
+
+    payload = json.dumps({"items": [{"desc": "replacement", "status": "done"}]})
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    items = load_backlog(tmp_path)
+    assert len(items) == 1
+    assert items[0]["status"] == "pending"
+
+
+def test_organize_backlog_will_not_rewrite_a_completed_record(tmp_path):
+    """An invented id colliding with history must not mutate it."""
+    done = _item("done1", status="done", description="original", priority=2)
+    save_backlog(tmp_path, [done, _item("p1")])
+
+    payload = json.dumps({"items": [{"id": "done1", "desc": "hijacked", "priority": 9}]})
+    with _client_returning(payload):
+        organize_backlog(tmp_path, client=object())
+
+    items = load_backlog(tmp_path)
+    survivor = next(i for i in items if i["id"] == "done1")
+    assert survivor == done, "the completed record must be untouched"
+    # The organizer's entry became a new pending task under a fresh id.
+    fresh = [i for i in items if i["id"] != "done1"]
+    assert len(fresh) == 1
+    assert fresh[0]["description"] == "hijacked"
+    assert fresh[0]["status"] == "pending"
+
+
+def test_organize_backlog_applies_only_supplied_fields(tmp_path):
+    save_backlog(tmp_path, [_item("a1", task_type="add_test",
+                                  description="keep", priority=3)])
+
+    with _client_returning(json.dumps({"items": [{"id": "a1", "priority": 8}]})):
+        organize_backlog(tmp_path, client=object())
+
+    item = load_backlog(tmp_path)[0]
+    assert item["priority"] == 8
+    assert item["task_type"] == "add_test"
+    assert item["description"] == "keep"


### PR DESCRIPTION
Closes #28.

`organize_backlog` was completely untested. It hands the pending backlog to an LLM and **rewrites the file from the reply**, so a bad response can lose or corrupt work that nothing else records.

**40 tests. backlog.py to 100%.**

## Six ways model output could corrupt the backlog

The response is now validated as a whole before anything is written, so one bad entry can't leave the backlog half-rewritten. Every one of these was reproducible:

| response | before |
|---|---|
| `{"items": []}` / no `items` key / wrong shape | **deleted every pending item** |
| `{"items": [{}]}` | replaced the whole backlog with one blank task |
| `{"id":"a1","desc":"","priority":null}` | blanked the description; a null priority makes `get_pending` **raise** while sorting |
| `[{"id":"a1"},{"id":"a1"}]` | appended the record twice — and `mark_done` stops at the first match, so the duplicate stayed pending and got worked again |
| `{"desc":"x","status":"done"}` | new entry declared itself done, deleting the omitted records and leaving **nothing pending to replace them** |
| `{"id":"done1","desc":"hijacked"}` | reconciliation searched *all* records, so an invented id colliding with history **mutated the completed record** in place and appended it twice |

Now: entries must be a recognised pending id or carry a non-empty description; supplied fields are type-checked with priority 1–10; null and blank count as omission; a repeated id rejects the response; new records are always `pending`; updates resolve only against pending records, and a colliding new id gets a fresh one.

Verified:
```
null/blank fields    -> d | priority 5          (originals kept)
duplicate ids        -> ['a1', 'b2']            (rejected)
invented id vs done  -> [('d1','original','done'), ('aaa2edc5','hijacked','pending')]
model-set status     -> [('x','pending')]
```

## Two more found by writing the tests

The early return only fired for a *completely* empty backlog, so a history of nothing but done/failed records still sent `"[]"` to the model — and anything it invented became new pending work.

Records were indexed directly for `id`, `task_type`, `description`, `priority` and `status`, so a hand-edited or legacy record missing a key raised out of a function whose contract is to log and leave the backlog alone. `chat_completion` is now inside the `try` for the same reason — it was safe only because `chat_completion` swallows its own errors, which made the contract accidental.

## What this does *not* fix

A reply echoing 3 of 10 items still deletes 7, and is indistinguishable from a correct pruning of 7 duplicates. Deletion-by-omission is the protocol, and no amount of validation makes it safe — it needs an explicit `keep`/`delete`/`merge` schema and a result the CLI can report. Filed as **#65**.

These guards close the cases that destroy or corrupt the backlog outright. They don't make omission safe, and I've said so rather than implying the path is now sound.

## Verification

`717 passed` locally, 3.10–3.14 in CI.

## Review

Codex, four rounds — it found the `{"items":[{}]}` bypass of my first guard, then the null-field/duplicate-id/history-mutation trio, each reproduced with direct probes before fixing. Antigravity timed out on the final round after reviewing earlier ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm