### PR TITLE
feat(storage): move append-only history into SQLite

### DIFF
--- a/src/ouroboros/evaluation.py
+++ b/src/ouroboros/evaluation.py
@@ -66,7 +66,6 @@ def record_improvement(result: "ImprovementResult", repo_root: Optional[Path] = 
     path = _history_path(repo_root)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    history = load_history(repo_root)
     record = EvaluationRecord(
         task_id=result.task.task_id,
         task_type=result.task.task_type,
@@ -88,9 +87,22 @@ def record_improvement(result: "ImprovementResult", repo_root: Optional[Path] = 
         feedback=result.details or "",
         timestamp=time.time(),
     )
-    history.append(record)
-
-    save_json_file(path, [r.to_dict() for r in history])
+    # Append, rather than load-modify-write the whole file. That read-rewrite
+    # was O(total history) per improvement and is what made these files grow
+    # into something worth capping.
+    #
+    # The PR already exists by the time this runs, so a database failure must
+    # not lose the record: fall back to the legacy JSON file, which
+    # _backfill_history_once will pick up once the database is writable again.
+    try:
+        _history_storage(repo_root).append_improvement(record.to_dict())
+    except Exception:
+        log.warning("Could not persist improvement to storage; keeping JSON copy",
+                    exc_info=True)
+        legacy = _load_legacy_history(repo_root)
+        legacy.append(record.to_dict())
+        save_json_file(path, legacy)
+        _history_storage(repo_root).mark_migration_pending(_HISTORY_MIGRATION)
 
     # Persist to SQLite
     try:
@@ -118,8 +130,75 @@ def record_improvement(result: "ImprovementResult", repo_root: Optional[Path] = 
         log.exception("Failed to persist metrics to SQLite")
 
 
+_HISTORY_MIGRATION = "improvement_history_v1"
+
+
+def _history_storage(repo_root: Optional[Path] = None) -> OuroborosStorage:
+    """Storage for the given repo, not just whichever one we started in.
+
+    load_history(tmp_path) has to read tmp_path's database, or a caller
+    pointing at another checkout silently gets this one's history.
+    """
+    if repo_root is None:
+        return OuroborosStorage()
+    return OuroborosStorage(db_path=Path(repo_root) / "config" / "ouroboros.db")
+
+
 def load_history(repo_root: Optional[Path] = None) -> List[EvaluationRecord]:
-    """Load improvement history from disk."""
+    """Load improvement history, oldest first.
+
+    Reads SQLite. On the first call after upgrading, the JSON file is
+    backfilled into the database; that is idempotent and leaves the file in
+    place, so rolling back to the previous version still finds it.
+    """
+    storage = _history_storage(repo_root)
+    if not storage.migration_done(_HISTORY_MIGRATION):
+        _backfill_history_once(repo_root)
+
+    return [
+        EvaluationRecord.from_dict(d)
+        for d in storage.get_improvement_history()
+        if isinstance(d, dict)
+    ]
+
+
+def _backfill_history_once(repo_root: Optional[Path]) -> None:
+    """Import the legacy JSON history, marking completion only when it all lands.
+
+    A count-based check would treat a partial import as finished: one
+    successful insert makes the table non-empty, and the next run would skip
+    the records that never made it.
+    """
+    storage = _history_storage(repo_root)
+    data = _load_legacy_history(repo_root)
+    if not data:
+        storage.mark_migration_done(_HISTORY_MIGRATION)
+        return
+
+    imported = 0
+    failed = 0
+    for record in data:
+        if not isinstance(record, dict):
+            continue
+        try:
+            imported += bool(storage.append_improvement(record))
+        except Exception:
+            failed += 1
+
+    if failed:
+        log.warning(
+            "Improvement history import incomplete: %d of %d records failed; "
+            "will retry", failed, len(data),
+        )
+        return
+
+    storage.mark_migration_done(_HISTORY_MIGRATION)
+    if imported:
+        log.info("Imported %d improvement records from JSON into SQLite", imported)
+
+
+def _load_legacy_history(repo_root: Optional[Path] = None) -> List[dict]:
+    """Read the pre-SQLite JSON history file, if it still exists."""
     data = load_json_file(
         _history_path(repo_root),
         default=[],
@@ -129,7 +208,7 @@ def load_history(repo_root: Optional[Path] = None) -> List[EvaluationRecord]:
     if not isinstance(data, list):
         log.warning("Improvement history is not a list, returning empty")
         return []
-    return [EvaluationRecord.from_dict(d) for d in data]
+    return data
 
 
 def check_pr_outcomes(repo_root: Optional[Path] = None) -> List[EvaluationRecord]:
@@ -170,13 +249,17 @@ def check_pr_outcomes(repo_root: Optional[Path] = None) -> List[EvaluationRecord
                     continue
                 record.outcome = state.lower()
                 record.feedback = feedback
+                # Update the one row rather than rewriting every record.
+                _history_storage(root).update_improvement(
+                    record.task_id, record.timestamp, record.to_dict()
+                )
                 updated = True
                 log.info("PR %s outcome updated: %s", record.pr_url, record.outcome)
         except Exception:
             log.debug("Could not check PR status for %s", record.pr_url)
 
     if updated:
-        save_json_file(_history_path(root), [r.to_dict() for r in history])
+        log.debug("PR outcomes updated in storage")
 
     return history
 

--- a/src/ouroboros/knowledge_base.py
+++ b/src/ouroboros/knowledge_base.py
@@ -1,8 +1,10 @@
 """Knowledge base -- persisted insights from community posts."""
 
+import json
 import logging
 import os
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .storage import load_json_file, save_json_file
@@ -11,13 +13,39 @@ log = logging.getLogger(__name__)
 
 KB_PATH = os.path.expanduser("~/.config/moltbook/knowledge_base.json")
 KB_DEFAULT = {"entries": [], "summary_cache": "", "summary_updated_at": 0}
+
+# Kept for the migration only. Entries live in SQLite now and are not capped:
+# the cap existed because the whole list was rewritten as JSON on every append,
+# so keeping more meant a bigger file to load each cycle.
 MAX_ENTRIES = 200
+
+# Completion marker: a non-empty table does not mean the import finished.
+KB_MIGRATION = "knowledge_entries_v1"
 _SUMMARY_MAX_AGE = 86400  # 24 hours
 _SUMMARY_NEW_ENTRY_THRESHOLD = 20
 
 
-def load_kb(path: Optional[str] = None) -> Dict[str, Any]:
-    """Load the knowledge base from disk."""
+def _storage() -> "OuroborosStorage":
+    from .storage import OuroborosStorage
+
+    return OuroborosStorage()
+
+
+def entry_fingerprint(entry: Dict[str, Any]) -> str:
+    """Stable identity for an entry, which carries no id of its own."""
+    from .storage import OuroborosStorage
+
+    return OuroborosStorage.record_fingerprint(
+        json.dumps(entry, sort_keys=True, default=str)
+    )
+
+
+def _load_scalars(path: Optional[str] = None) -> Dict[str, Any]:
+    """Read the summary cache, which stays in JSON.
+
+    Two small fields that never grow, so there is nothing to gain from moving
+    them; only the unbounded entries list needed a table.
+    """
     p = path or KB_PATH
     return load_json_file(
         p,
@@ -27,21 +55,56 @@ def load_kb(path: Optional[str] = None) -> Dict[str, Any]:
     )
 
 
+def load_kb(path: Optional[str] = None) -> Dict[str, Any]:
+    """Return the knowledge base: entries from SQLite, cache from JSON.
+
+    Any entries still in the JSON file are imported on first read, so an
+    existing deployment needs no manual step.
+    """
+    kb = dict(_load_scalars(path))
+    storage = _storage()
+
+    legacy = kb.get("entries") or []
+    if storage.migration_done(KB_MIGRATION):
+        legacy = []
+    if legacy:
+        # save_kb stops writing entries, so the next summary refresh would
+        # erase them from the file. Keep a copy before that happens.
+        from .state_migration import freeze_rollback_snapshot
+
+        if freeze_rollback_snapshot(Path(path or KB_PATH)) is None:
+            log.warning("Skipping knowledge cutover: could not snapshot the file")
+            return kb
+        imported = sum(
+            1 for entry in legacy
+            if isinstance(entry, dict)
+            and storage.append_knowledge(entry, entry_fingerprint(entry))
+        )
+        storage.mark_migration_done(KB_MIGRATION)
+        if imported:
+            log.info("Imported %d knowledge entries from JSON into SQLite", imported)
+
+    kb["entries"] = storage.get_knowledge_entries()
+    return kb
+
+
 def save_kb(kb: Dict[str, Any], path: Optional[str] = None) -> None:
-    """Atomic write of the knowledge base."""
+    """Persist the summary cache. Entries are owned by SQLite."""
     p = path or KB_PATH
-    save_json_file(p, kb, sort_keys=True)
+    scalars = {k: v for k, v in kb.items() if k != "entries"}
+    save_json_file(p, scalars, sort_keys=True)
 
 
 def add_entries(entries: List[Dict[str, Any]], path: Optional[str] = None) -> None:
-    """Append entries to the knowledge base and trim to MAX_ENTRIES."""
+    """Append entries. No cap -- appends no longer rewrite the whole list."""
     if not entries:
         return
-    kb = load_kb(path)
-    kb["entries"].extend(entries)
-    if len(kb["entries"]) > MAX_ENTRIES:
-        kb["entries"] = kb["entries"][-MAX_ENTRIES:]
-    save_kb(kb, path)
+    pairs = [
+        (entry, entry_fingerprint(entry))
+        for entry in entries
+        if isinstance(entry, dict)
+    ]
+    _storage().append_knowledge_batch(pairs)
 
 
 def get_summary(

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -27,7 +27,15 @@ _shutdown_event = lifecycle.shutdown_event
 MAX_SELF_QUESTION_LOG = 200
 MAX_BACKOFF_SECONDS = 900  # 15 min cap
 MAX_SEEN_POST_IDS = 200
+# Size of the recent-comment window kept in memory. Comments themselves are
+# stored in SQLite without a limit; this only bounds what load_state hydrates,
+# since every reader looks at a tail slice or the last seven days.
 MAX_COMMENT_HISTORY = 100
+
+# Set by load_state. save_state only drops comment_history once the records
+# are known to be in the database; it is stripped from what gets written.
+_COMMENTS_IN_SQLITE = "_comments_in_sqlite"
+_COMMENT_MIGRATION = "comment_history_v1"
 MAX_SELF_UPGRADES = 50
 MAX_COMMUNITY_HISTORY = 20
 
@@ -367,18 +375,82 @@ def load_state() -> Dict[str, Any]:
     # timestamps with defaults and the agent would repeat work it had already
     # done. load_json_file distinguishes missing from unreadable.
     path = _state_path()
-    return load_json_file(
+    state = load_json_file(
         path,
         default=_default_state(),
         error_msg=f"Corrupt state file at {path}, returning default",
         logger=log,
     )
 
+    # comment_history lives in SQLite. Hydrate a recent window so the readers
+    # that slice state["comment_history"] keep working unchanged, while the
+    # full history stays in the database and out of this file -- it was 102 KB
+    # of a 169 KB state.json, rewritten every cycle.
+    try:
+        storage = _comment_storage()
+        _drain_comment_outbox(state, storage)
+        _drain_knowledge_outbox(state)
+        legacy = state.get("comment_history") or []
+        if storage.migration_done(_COMMENT_MIGRATION):
+            legacy = []
+        if legacy:
+            # save_state stops writing this list, so the next save would erase
+            # it. Snapshot before that, without depending on the startup
+            # migration having run first.
+            from .state_migration import freeze_rollback_snapshot
+
+            snapshot = freeze_rollback_snapshot(Path(path))
+            if snapshot is None:
+                # No rollback artifact means no cutover. Leave the file
+                # authoritative and try again next start.
+                log.warning("Skipping comment cutover: could not snapshot %s", path)
+                state[_COMMENTS_IN_SQLITE] = False
+                return state
+            imported = 0
+            failed = 0
+            for c in legacy:
+                if not isinstance(c, dict):
+                    continue
+                try:
+                    imported += bool(storage.append_comment(c))
+                except Exception:
+                    failed += 1
+            if failed:
+                # save_state would drop the list next, so a partial import
+                # would lose the records that did not make it.
+                log.warning(
+                    "Skipping comment cutover: %d of %d records could not be "
+                    "imported", failed, len(legacy),
+                )
+                state[_COMMENTS_IN_SQLITE] = False
+                return state
+            # Only now is the file safe to stop writing.
+            storage.mark_migration_done(_COMMENT_MIGRATION)
+            if imported:
+                log.info("Imported %d comments from state.json into SQLite", imported)
+        state["comment_history"] = storage.get_comment_history(limit=MAX_COMMENT_HISTORY)
+        state[_COMMENTS_IN_SQLITE] = True
+    except Exception:
+        # Fall back to whatever the file had rather than losing the window.
+        log.warning("Could not load comment history from storage", exc_info=True)
+        state[_COMMENTS_IN_SQLITE] = False
+
+    return state
+
 
 def save_state(state: Dict[str, Any]) -> None:
     path = _state_path()
     _trim_state(state)
-    save_json_file(path, state, sort_keys=True)
+    # comment_history is owned by SQLite once the cutover succeeded; writing
+    # it here too would recreate the bloat and give two sources of truth. If
+    # the cutover was skipped -- no snapshot, or a record that would not
+    # import -- the file is still authoritative and must keep the list.
+    cut_over = state.get(_COMMENTS_IN_SQLITE, False)
+    to_write = {
+        k: v for k, v in state.items()
+        if k != _COMMENTS_IN_SQLITE and not (cut_over and k == "comment_history")
+    }
+    save_json_file(path, to_write, sort_keys=True)
 
 
 def _send_telegram_message(token: str, chat_id: str, text: str) -> None:
@@ -429,7 +501,89 @@ def _trim_self_question_log(state: Dict[str, Any]) -> None:
         state["self_question_log"] = log_list[-MAX_SELF_QUESTION_LOG:]
 
 
+def _comment_storage() -> Any:
+    from .storage import OuroborosStorage
+
+    return OuroborosStorage()
+
+
+def record_comment(state: Dict[str, Any], entry: Dict[str, Any]) -> None:
+    """Persist a posted comment and make it visible to this cycle's readers.
+
+    The comment is already public by the time this runs, so a database
+    failure must not lose the local record. On failure the entry goes to an
+    outbox that save_state does persist, and load_state retries it -- without
+    that it would live only in the in-memory list, which save_state
+    deliberately drops.
+    """
+    try:
+        _comment_storage().append_comment(entry)
+    except Exception:
+        log.warning("Could not persist comment; queued for retry", exc_info=True)
+        state.setdefault("comment_outbox", []).append(entry)
+        # Written now, not at the end of the cycle: the comment is already
+        # public, and a crash before the cycle-end save would lose the only
+        # local record of it.
+        try:
+            save_state(state)
+        except Exception:
+            log.error("Could not persist the comment outbox", exc_info=True)
+    state.setdefault("comment_history", []).append(entry)
+
+
+def _record_knowledge(state: Dict[str, Any], entries: List[Dict[str, Any]]) -> None:
+    """Persist knowledge entries, queueing the batch if the write fails.
+
+    The source posts are added to seen_post_ids before this runs, so a lost
+    batch is never regenerated -- later cycles skip those posts entirely.
+    """
+    from .knowledge_base import add_entries
+
+    try:
+        add_entries(entries)
+        log.info("[knowledge-base] Added %d entries", len(entries))
+    except Exception:
+        log.warning("Could not persist knowledge entries; queued", exc_info=True)
+        state.setdefault("knowledge_outbox", []).extend(entries)
+        try:
+            save_state(state)
+        except Exception:
+            log.error("Could not persist the knowledge outbox", exc_info=True)
+
+
+def _drain_knowledge_outbox(state: Dict[str, Any]) -> None:
+    """Retry a knowledge batch whose write failed on an earlier cycle."""
+    queued = state.get("knowledge_outbox") or []
+    if not queued:
+        return
+    from .knowledge_base import add_entries
+
+    try:
+        add_entries(queued)
+    except Exception:
+        return  # still failing; keep it queued
+    state["knowledge_outbox"] = []
+    log.info("Recovered %d queued knowledge entries", len(queued))
+
+
+def _drain_comment_outbox(state: Dict[str, Any], storage: Any) -> None:
+    """Retry comments whose database write failed on an earlier cycle."""
+    outbox = state.get("comment_outbox") or []
+    if not outbox:
+        return
+    remaining = []
+    for entry in outbox:
+        try:
+            storage.append_comment(entry)
+        except Exception:
+            remaining.append(entry)
+    state["comment_outbox"] = remaining
+    if len(remaining) < len(outbox):
+        log.info("Recovered %d queued comments into storage", len(outbox) - len(remaining))
+
+
 def _trim_comment_history(state: Dict[str, Any], limit: int = 80) -> None:
+    """Bound the in-memory window. SQLite keeps the full history."""
     history = state.get("comment_history", [])
     if len(history) > limit:
         state["comment_history"] = history[-limit:]
@@ -727,6 +881,18 @@ def run_loop() -> int:
     cfg = load_runner_config()
     state = load_state()
 
+    # Backfill the JSON history into SQLite. Idempotent and non-destructive,
+    # so it is safe to run on every start and needs no separate deploy step.
+    try:
+        from .codebase import get_repo_root
+        from .state_migration import migrate_json_history
+
+        migrate_json_history(get_repo_root())
+    except Exception:
+        # A failed backfill must not stop the agent; the JSON files are still
+        # there and the next start will try again.
+        log.warning("State migration skipped", exc_info=True)
+
     try:
         creds: Optional[Credentials] = load_credentials()
     except MoltbookError as exc:
@@ -881,7 +1047,7 @@ def run_loop() -> int:
                         }
                         if not cfg.dry_run and comment_result:
                             comment_entry["comment_id"] = comment_result.get("id")
-                        state.setdefault("comment_history", []).append(comment_entry)
+                        record_comment(state, comment_entry)
 
                         # -- Comment mining: extract codebase improvement insights --
                         if (
@@ -984,8 +1150,7 @@ def run_loop() -> int:
                                         })
 
                         if kb_entries:
-                            add_entries(kb_entries)
-                            log.info("[knowledge-base] Added %d entries", len(kb_entries))
+                            _record_knowledge(state, kb_entries)
                     except Exception:
                         log.exception("Knowledge base population failed")
 

--- a/src/ouroboros/state_migration.py
+++ b/src/ouroboros/state_migration.py
@@ -1,0 +1,170 @@
+"""One-way backfill of the JSON history files into SQLite.
+
+The three append-only collections named in the SQLite migration --
+comment_history, improvement_history and the knowledge base -- used to live in
+JSON files that were read and rewritten whole on every cycle. Each therefore
+carried a cap, and the agent continuously discarded its own history to keep the
+files small.
+
+This module moves what exists into the database once. It is deliberately
+conservative:
+
+* Idempotent. Every insert is INSERT OR IGNORE against a natural key, so
+  running it twice adds nothing. Safe to call on every start.
+* Non-destructive. Nothing is deleted. The JSON files are left exactly where
+  they are, so rolling back is a matter of deploying the previous version.
+* Additive. If a record cannot be read it is counted and skipped rather than
+  aborting the run, since a single bad row should not keep the agent from
+  starting.
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .storage import OuroborosStorage, load_json_file
+
+log = logging.getLogger(__name__)
+
+# Marker recorded in the DB so a completed backfill is not re-attempted, and so
+# `status` can say whether it has run.
+_MIGRATION_KEY = "json_history_v1"
+
+
+@dataclass
+class MigrationReport:
+    comments: int = 0
+    improvements: int = 0
+    knowledge: int = 0
+    skipped: List[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.comments + self.improvements + self.knowledge
+
+    def summary(self) -> str:
+        parts = [
+            f"{self.comments} comments",
+            f"{self.improvements} improvements",
+            f"{self.knowledge} knowledge entries",
+        ]
+        text = "migrated " + ", ".join(parts)
+        if self.skipped:
+            text += f" ({len(self.skipped)} records skipped)"
+        return text
+
+
+def _entry_fingerprint(entry: Dict[str, Any]) -> str:
+    """Delegate to the knowledge_base implementation.
+
+    load_kb imports legacy entries too. Two hashes of the same entry means
+    whichever path runs second inserts it again.
+    """
+    from .knowledge_base import entry_fingerprint
+
+    return entry_fingerprint(entry)
+
+
+def freeze_rollback_snapshot(path: Path) -> Optional[Path]:
+    """Copy a legacy file aside once, before it stops being authoritative.
+
+    Both state.json and knowledge_base.json keep being written after the
+    cutover -- for the runtime pointers and the summary cache -- but without
+    the collections that moved. The first such write would erase the very
+    records the rollback story depends on, so the pre-cutover contents are
+    preserved next to the original.
+    """
+    if not path.exists():
+        return None
+    snapshot = path.with_name(path.name + ".pre-sqlite")
+    if snapshot.exists() and snapshot.stat().st_size > 0:
+        return snapshot
+
+    # Temp file then atomic rename: writing straight to the destination can
+    # leave a truncated file that the next call accepts merely because it
+    # exists, which is worse than no snapshot at all.
+    tmp = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+        os.close(fd)
+        tmp = Path(tmp_name)
+        shutil.copy2(path, tmp)
+        if tmp.stat().st_size != path.stat().st_size:
+            raise OSError("snapshot size mismatch")
+        os.replace(tmp, snapshot)
+        log.info("Kept a pre-migration copy of %s at %s", path.name, snapshot.name)
+        return snapshot
+    except OSError:
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
+        log.warning("Could not snapshot %s for rollback", path, exc_info=True)
+        return None
+
+
+def migrate_json_history(
+    repo_root: Path,
+    storage: Optional[OuroborosStorage] = None,
+    *,
+    state_path: Optional[Path] = None,
+    history_path: Optional[Path] = None,
+    kb_path: Optional[Path] = None,
+) -> MigrationReport:
+    """Backfill the JSON history files into SQLite. Idempotent."""
+    store = storage or OuroborosStorage()
+    report = MigrationReport()
+
+    # -- comment_history, which lives inside state.json ---------------------
+    state_file = state_path or Path(
+        os.path.expanduser("~/.config/moltbook/state.json")
+    )
+    freeze_rollback_snapshot(state_file)
+    state = load_json_file(state_file, default={})
+    for record in state.get("comment_history", []) if isinstance(state, dict) else []:
+        if not isinstance(record, dict):
+            report.skipped.append("comment_history: non-object record")
+            continue
+        try:
+            if store.append_comment(record):
+                report.comments += 1
+        except Exception as exc:  # pragma: no cover - defensive
+            report.skipped.append(f"comment_history: {exc}")
+
+    # -- improvement_history, its own file in the repo ----------------------
+    hist_file = history_path or (repo_root / "config" / "improvement_history.json")
+    history = load_json_file(hist_file, default=[])
+    for record in history if isinstance(history, list) else []:
+        if not isinstance(record, dict):
+            report.skipped.append("improvement_history: non-object record")
+            continue
+        try:
+            if store.append_improvement(record):
+                report.improvements += 1
+        except Exception as exc:  # pragma: no cover - defensive
+            report.skipped.append(f"improvement_history: {exc}")
+
+    # -- knowledge base, outside the repo -----------------------------------
+    from .knowledge_base import KB_PATH
+
+    kb_file = kb_path or Path(KB_PATH)
+    freeze_rollback_snapshot(kb_file)
+    kb = load_json_file(kb_file, default={})
+    for entry in kb.get("entries", []) if isinstance(kb, dict) else []:
+        if not isinstance(entry, dict):
+            report.skipped.append("knowledge_base: non-object entry")
+            continue
+        try:
+            if store.append_knowledge(entry, _entry_fingerprint(entry)):
+                report.knowledge += 1
+        except Exception as exc:  # pragma: no cover - defensive
+            report.skipped.append(f"knowledge_base: {exc}")
+
+    if report.total or report.skipped:
+        log.info("State migration: %s", report.summary())
+    for reason in report.skipped:
+        log.warning("State migration skipped a record -- %s", reason)
+
+    return report

--- a/src/ouroboros/storage.py
+++ b/src/ouroboros/storage.py
@@ -173,6 +173,63 @@ class OuroborosStorage:
                     FOREIGN KEY (cycle_id) REFERENCES cycles (id)
                 )
             """)
+            # Append-only history. These lived in JSON files that were read
+            # and rewritten whole on every cycle, which is why each had a cap
+            # -- comment_history alone was 102 KB of a 169 KB state.json. The
+            # caps meant the agent continuously discarded its own history to
+            # keep the file small; a table has no such pressure.
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS comment_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts REAL NOT NULL,
+                    post_id TEXT,
+                    comment_id TEXT,
+                    -- Content hash, not (post_id, comment_id): comment_id is
+                    -- null on every historical record, and SQLite treats NULL
+                    -- as distinct from NULL, so a UNIQUE over those columns
+                    -- would let a re-run insert everything again.
+                    fingerprint TEXT UNIQUE,
+                    payload TEXT NOT NULL
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_comment_history_ts "
+                "ON comment_history (ts DESC)"
+            )
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS improvement_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts REAL NOT NULL,
+                    task_id TEXT,
+                    outcome TEXT,
+                    -- Identity is the task and its timestamp, but hashed for
+                    -- the same NULL reason as above.
+                    fingerprint TEXT UNIQUE,
+                    payload TEXT NOT NULL
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_improvement_history_ts "
+                "ON improvement_history (ts DESC)"
+            )
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS knowledge_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts REAL NOT NULL,
+                    fingerprint TEXT UNIQUE,
+                    payload TEXT NOT NULL
+                )
+            """)
+            # Explicit completion markers. Inferring "already migrated" from
+            # a non-empty table is wrong: a partial import leaves rows behind,
+            # and the next start would skip the remaining legacy records and
+            # then strip the file that still held them.
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS migrations (
+                    name TEXT PRIMARY KEY,
+                    completed_at REAL NOT NULL
+                )
+            """)
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS embeddings (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -237,3 +294,187 @@ class OuroborosStorage:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(query, params)
             return [dict(row) for row in cursor.fetchall()]
+
+    # -- Append-only history ------------------------------------------------
+    #
+    # Each row keeps the whole record as JSON alongside the few columns worth
+    # indexing. The shapes here are produced by an LLM and have changed before,
+    # so pinning every field into a column would mean a schema migration each
+    # time one gains a key.
+
+    @staticmethod
+    def record_fingerprint(*parts: Any) -> str:
+        """Stable identity for a record with no reliable natural key.
+
+        A UNIQUE over nullable columns does not dedupe, because SQLite treats
+        every NULL as distinct. Hashing the identifying values sidesteps that.
+        """
+        import hashlib
+
+        # json rather than str-join: it encodes None distinctly from "", so a
+        # missing field and an empty one cannot hash to the same record.
+        joined = json.dumps([None if p is None else str(p) for p in parts])
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:32]
+
+    @staticmethod
+    def _timestamp(value: Any) -> float:
+        """Coerce a record timestamp, treating only None/invalid as missing.
+
+        `value or time.time()` would replace a legitimate 0.0 with now, which
+        reorders the oldest record to the newest.
+        """
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return time.time()
+
+    def append_comment(self, record: Dict[str, Any]) -> bool:
+        """Record a posted comment. Returns False if it was already recorded."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO comment_history "
+                "(ts, post_id, comment_id, fingerprint, payload) VALUES (?, ?, ?, ?, ?)",
+                (
+                    self._timestamp(record.get("ts")),
+                    record.get("post_id"),
+                    record.get("comment_id"),
+                    self.record_fingerprint(
+                        record.get("post_id"),
+                        record.get("comment_id"),
+                        record.get("comment"),
+                    ),
+                    json.dumps(record),
+                ),
+            )
+            return cursor.rowcount > 0
+
+    def get_comment_history(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Return comments oldest-first, or the newest `limit` of them."""
+        return self._recent_payloads("comment_history", limit)
+
+    def comment_count(self) -> int:
+        return self._count("comment_history")
+
+    def append_improvement(self, record: Dict[str, Any]) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO improvement_history "
+                "(ts, task_id, outcome, fingerprint, payload) VALUES (?, ?, ?, ?, ?)",
+                (
+                    self._timestamp(record.get("timestamp")),
+                    record.get("task_id"),
+                    record.get("outcome"),
+                    self.record_fingerprint(
+                        record.get("task_id"), record.get("timestamp")
+                    ),
+                    json.dumps(record),
+                ),
+            )
+            return cursor.rowcount > 0
+
+    def update_improvement(self, task_id: str, ts: float, record: Dict[str, Any]) -> bool:
+        """Rewrite one record in place, for PR outcome polling."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE improvement_history SET outcome = ?, payload = ? "
+                "WHERE fingerprint = ?",
+                (
+                    record.get("outcome"),
+                    json.dumps(record),
+                    self.record_fingerprint(task_id, ts),
+                ),
+            )
+            return cursor.rowcount > 0
+
+    def get_improvement_history(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        return self._recent_payloads("improvement_history", limit)
+
+    def improvement_count(self) -> int:
+        return self._count("improvement_history")
+
+    def append_knowledge_batch(self, entries: List[tuple]) -> int:
+        """Insert (entry, fingerprint) pairs in one transaction.
+
+        Per-entry commits leave earlier rows written and later ones lost if
+        one fails partway, and the caller has already marked the source posts
+        seen -- so the missing insights are never regenerated.
+        """
+        if not entries:
+            return 0
+        with self._connect() as conn:
+            cursor = conn.executemany(
+                "INSERT OR IGNORE INTO knowledge_entries (ts, fingerprint, payload) "
+                "VALUES (?, ?, ?)",
+                [
+                    (self._timestamp(entry.get("ts")), fingerprint, json.dumps(entry))
+                    for entry, fingerprint in entries
+                ],
+            )
+            return cursor.rowcount
+
+    def append_knowledge(self, entry: Dict[str, Any], fingerprint: str) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO knowledge_entries (ts, fingerprint, payload) "
+                "VALUES (?, ?, ?)",
+                (self._timestamp(entry.get("ts")), fingerprint, json.dumps(entry)),
+            )
+            return cursor.rowcount > 0
+
+    def get_knowledge_entries(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        return self._recent_payloads("knowledge_entries", limit)
+
+    def knowledge_count(self) -> int:
+        return self._count("knowledge_entries")
+
+    def _recent_payloads(self, table: str, limit: Optional[int]) -> List[Dict[str, Any]]:
+        """Newest `limit` rows, returned oldest-first.
+
+        Ordered by insertion (id), not timestamp. The JSON lists these replace
+        were in append order, and callers slice them with [-n:] to mean "most
+        recent". Sorting by ts would reorder history whenever the Pi's clock
+        was corrected, or whenever a record carried a missing or bogus
+        timestamp, and change which records a tail slice selects.
+        """
+        with self._connect() as conn:
+            if limit is None:
+                rows = conn.execute(
+                    f"SELECT payload FROM {table} ORDER BY id ASC"  # noqa: S608
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    f"SELECT payload FROM ("  # noqa: S608
+                    f"  SELECT payload, id FROM {table} ORDER BY id DESC LIMIT ?"
+                    f") ORDER BY id ASC",
+                    (limit,),
+                ).fetchall()
+        out = []
+        for (payload,) in rows:
+            try:
+                out.append(json.loads(payload))
+            except (json.JSONDecodeError, TypeError):
+                log.warning("Skipping unreadable %s row", table)
+        return out
+
+    def migration_done(self, name: str) -> bool:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM migrations WHERE name = ?", (name,)
+            ).fetchone()
+        return row is not None
+
+    def mark_migration_done(self, name: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO migrations (name, completed_at) VALUES (?, ?)",
+                (name, time.time()),
+            )
+
+    def mark_migration_pending(self, name: str) -> None:
+        """Clear a completion marker so the import runs again."""
+        with self._connect() as conn:
+            conn.execute("DELETE FROM migrations WHERE name = ?", (name,))
+
+    def _count(self, table: str) -> int:
+        with self._connect() as conn:
+            return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared test fixtures.
+
+The important one is the storage guard: OuroborosStorage() with no arguments
+resolves to <repo>/config/ouroboros.db, which on a deployment is live agent
+state. A test that constructs one without a path would read and write the real
+database -- two stray improvement records got into it exactly that way while
+this suite was being written.
+"""
+
+import pytest
+
+from ouroboros import storage as storage_module
+
+
+@pytest.fixture(autouse=True)
+def _never_touch_the_real_database(tmp_path, monkeypatch):
+    """Redirect the default storage path into the test's tmp_path."""
+    real_init = storage_module.OuroborosStorage.__init__
+
+    def guarded_init(self, db_path=None):
+        if db_path is None:
+            db_path = tmp_path / "config" / "ouroboros.db"
+        real_init(self, db_path=db_path)
+
+    monkeypatch.setattr(storage_module.OuroborosStorage, "__init__", guarded_init)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -155,8 +155,9 @@ def test_check_pr_outcomes_updates_success_records(mock_run, _mock_feedback, tmp
     assert history[0].outcome == "merged"
     assert history[0].feedback == "Looks good"
 
-    persisted = json.loads(history_file.read_text())
-    assert persisted[0]["outcome"] == "merged"
+    # Persistence is now SQLite, so read it back the way callers do rather
+    # than inspecting the legacy JSON file.
+    assert load_history(tmp_path)[0].outcome == "merged"
 
 
 # -- centralised JSON IO -----------------------------------------------------

--- a/tests/test_feed_intelligence.py
+++ b/tests/test_feed_intelligence.py
@@ -151,16 +151,21 @@ def test_generate_kb_summary_returns_none_on_error():
 def test_kb_load_save_roundtrip(tmp_path):
     from ouroboros.knowledge_base import load_kb, save_kb
 
+    from ouroboros.knowledge_base import add_entries
+
     path = str(tmp_path / "kb.json")
     kb = load_kb(path)
     assert kb["entries"] == []
 
-    kb["entries"].append({"insight": "test", "tags": [], "ts": 100})
+    # Entries are owned by SQLite now; save_kb persists only the summary cache.
+    add_entries([{"insight": "test", "tags": [], "ts": 100}], path)
+    kb["summary_cache"] = "a summary"
     save_kb(kb, path)
 
     kb2 = load_kb(path)
     assert len(kb2["entries"]) == 1
     assert kb2["entries"][0]["insight"] == "test"
+    assert kb2["summary_cache"] == "a summary"
 
 
 def test_kb_add_entries(tmp_path):
@@ -174,17 +179,19 @@ def test_kb_add_entries(tmp_path):
     assert len(kb["entries"]) == 5
 
 
-def test_kb_add_entries_trims(tmp_path):
+def test_kb_add_entries_no_longer_discards_history(tmp_path):
+    """The old 200-entry cap existed because every append rewrote the whole
+    JSON list. Appending a row has no such pressure, so nothing is dropped."""
     from ouroboros.knowledge_base import MAX_ENTRIES, add_entries, load_kb
 
     path = str(tmp_path / "kb.json")
-    entries = [{"insight": f"i_{i}", "tags": [], "ts": i} for i in range(MAX_ENTRIES + 10)]
-    add_entries(entries, path)
+    count = MAX_ENTRIES + 10
+    add_entries([{"insight": f"i_{i}", "tags": [], "ts": i} for i in range(count)], path)
 
     kb = load_kb(path)
-    assert len(kb["entries"]) == MAX_ENTRIES
-    # Should keep the latest entries
-    assert kb["entries"][-1]["insight"] == f"i_{MAX_ENTRIES + 9}"
+    assert len(kb["entries"]) == count
+    assert kb["entries"][0]["insight"] == "i_0", "the oldest entry survives"
+    assert kb["entries"][-1]["insight"] == f"i_{count - 1}"
 
 
 def test_kb_get_summary_cached(tmp_path):

--- a/tests/test_knowledge_base.py
+++ b/tests/test_knowledge_base.py
@@ -20,24 +20,46 @@ class TestKnowledgeBase:
         assert kb["summary_updated_at"] == 0
 
     def test_save_load_kb(self):
-        data = {"entries": [{"ts": 100, "insight": "test"}], "summary_cache": "test summary", "summary_updated_at": 100}
-        save_kb(data, str(self.kb_file))
-        
+        # save_kb persists the summary cache; entries are owned by SQLite.
+        add_entries([{"ts": 100, "insight": "test"}], str(self.kb_file))
+        save_kb(
+            {"summary_cache": "test summary", "summary_updated_at": 100},
+            str(self.kb_file),
+        )
+
         loaded = load_kb(str(self.kb_file))
         assert loaded["entries"][0]["insight"] == "test"
         assert loaded["summary_cache"] == "test summary"
 
-    def test_add_entries_bounded(self):
-        # Initial entries
+    def test_legacy_json_entries_are_imported_once(self):
+        """An existing deployment must not need a manual step."""
+        import json as _json
+
+        self.kb_file.write_text(_json.dumps({
+            "entries": [{"ts": 1, "insight": "from json"}],
+            "summary_cache": "",
+            "summary_updated_at": 0,
+        }))
+
+        first = load_kb(str(self.kb_file))
+        second = load_kb(str(self.kb_file))
+
+        assert [e["insight"] for e in first["entries"]] == ["from json"]
+        assert [e["insight"] for e in second["entries"]] == ["from json"]
+
+    def test_add_entries_keeps_everything(self):
+        """No cap: the 200-entry limit existed only because each append
+        rewrote the whole JSON list."""
         add_entries([{"ts": i, "insight": f"i{i}"} for i in range(150)], str(self.kb_file))
+        assert len(load_kb(str(self.kb_file))["entries"]) == 150
+
+        add_entries(
+            [{"ts": i + 150, "insight": f"i{i+150}"} for i in range(100)],
+            str(self.kb_file),
+        )
         kb = load_kb(str(self.kb_file))
-        assert len(kb["entries"]) == 150
-        
-        # Add 100 more, total 250, should be trimmed to 200
-        add_entries([{"ts": i + 150, "insight": f"i{i+150}"} for i in range(100)], str(self.kb_file))
-        kb = load_kb(str(self.kb_file))
-        assert len(kb["entries"]) == 200
-        assert kb["entries"][0]["insight"] == "i50" # First 50 dropped
+        assert len(kb["entries"]) == 250
+        assert kb["entries"][0]["insight"] == "i0", "nothing is dropped"
 
     @patch("ouroboros.llm.generate_kb_summary")
     def test_get_summary_refresh(self, mock_gen):

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -1,0 +1,693 @@
+"""Tests for the one-way JSON -> SQLite history backfill."""
+
+import json
+
+import pytest
+
+from ouroboros.state_migration import MigrationReport, migrate_json_history
+from ouroboros.storage import OuroborosStorage
+
+
+@pytest.fixture
+def store(tmp_path):
+    return OuroborosStorage(db_path=tmp_path / "ouroboros.db")
+
+
+def _write(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _comment(i):
+    return {"ts": float(i), "post_id": f"p{i}", "comment": f"text {i}", "title": "t"}
+
+
+def _improvement(i):
+    return {"task_id": f"t{i}", "timestamp": float(i), "outcome": "success",
+            "task_type": "fix_bug", "description": "d", "test_delta": {},
+            "pr_url": "", "feedback": ""}
+
+
+def _paths(tmp_path):
+    return {
+        "state_path": tmp_path / "state.json",
+        "history_path": tmp_path / "improvement_history.json",
+        "kb_path": tmp_path / "knowledge_base.json",
+    }
+
+
+# -- the happy path ----------------------------------------------------------
+
+def test_migrates_all_three_collections(tmp_path, store):
+    paths = _paths(tmp_path)
+    _write(paths["state_path"], {"comment_history": [_comment(1), _comment(2)]})
+    _write(paths["history_path"], [_improvement(1)])
+    _write(paths["kb_path"], {"entries": [{"insight": "a"}, {"insight": "b"}]})
+
+    report = migrate_json_history(tmp_path, store, **paths)
+
+    assert (report.comments, report.improvements, report.knowledge) == (2, 1, 2)
+    assert store.comment_count() == 2
+    assert store.improvement_count() == 1
+    assert store.knowledge_count() == 2
+
+
+def test_is_idempotent(tmp_path, store):
+    """Runs on every start, so a second pass must add nothing."""
+    paths = _paths(tmp_path)
+    _write(paths["state_path"], {"comment_history": [_comment(1), _comment(2)]})
+    _write(paths["history_path"], [_improvement(1)])
+
+    first = migrate_json_history(tmp_path, store, **paths)
+    second = migrate_json_history(tmp_path, store, **paths)
+
+    assert first.total == 3
+    assert second.total == 0
+    assert store.comment_count() == 2
+    assert store.improvement_count() == 1
+
+
+def test_comments_dedupe_without_a_comment_id(tmp_path, store):
+    """comment_id is null on every historical record.
+
+    A UNIQUE over (post_id, comment_id) does not dedupe those, because SQLite
+    treats each NULL as distinct -- a re-run would insert all of them again.
+    """
+    paths = _paths(tmp_path)
+    records = [{"ts": 1.0, "post_id": "p1", "comment_id": None, "comment": "x"}]
+    _write(paths["state_path"], {"comment_history": records})
+
+    migrate_json_history(tmp_path, store, **paths)
+    migrate_json_history(tmp_path, store, **paths)
+
+    assert store.comment_count() == 1
+
+
+def test_does_not_delete_the_source_files(tmp_path, store):
+    """The JSON files are the rollback path."""
+    paths = _paths(tmp_path)
+    _write(paths["state_path"], {"comment_history": [_comment(1)]})
+    _write(paths["history_path"], [_improvement(1)])
+    _write(paths["kb_path"], {"entries": [{"insight": "a"}]})
+
+    migrate_json_history(tmp_path, store, **paths)
+
+    for path in paths.values():
+        assert path.exists(), path
+
+
+def test_preserves_the_full_record(tmp_path, store):
+    paths = _paths(tmp_path)
+    record = {"ts": 1.0, "post_id": "p1", "comment": "body", "title": "T",
+              "content": "original post", "extra_field": [1, 2, 3]}
+    _write(paths["state_path"], {"comment_history": [record]})
+
+    migrate_json_history(tmp_path, store, **paths)
+
+    assert store.get_comment_history()[0] == record
+
+
+def test_preserves_the_json_list_order_exactly(tmp_path, store):
+    """Append order, not timestamp order: the JSON list was the record of
+    sequence, and a clock correction must not reshuffle history."""
+    paths = _paths(tmp_path)
+    _write(paths["state_path"],
+           {"comment_history": [_comment(3), _comment(1), _comment(2)]})
+
+    migrate_json_history(tmp_path, store, **paths)
+
+    assert [c["ts"] for c in store.get_comment_history()] == [3.0, 1.0, 2.0]
+
+
+# -- missing and malformed input ---------------------------------------------
+
+def test_missing_files_are_not_an_error(tmp_path, store):
+    report = migrate_json_history(tmp_path, store, **_paths(tmp_path))
+    assert report.total == 0
+    assert report.skipped == []
+
+
+def test_corrupt_file_does_not_abort_the_rest(tmp_path, store):
+    """One unreadable file must not block the other two."""
+    paths = _paths(tmp_path)
+    paths["state_path"].write_text("{ not json")
+    _write(paths["history_path"], [_improvement(1)])
+
+    report = migrate_json_history(tmp_path, store, **paths)
+
+    assert report.improvements == 1
+
+
+def test_non_object_records_are_skipped_not_fatal(tmp_path, store):
+    paths = _paths(tmp_path)
+    _write(paths["state_path"],
+           {"comment_history": ["a string", _comment(1), None]})
+
+    report = migrate_json_history(tmp_path, store, **paths)
+
+    assert report.comments == 1
+    assert len(report.skipped) == 2
+    assert store.comment_count() == 1
+
+
+def test_wrong_shaped_state_is_tolerated(tmp_path, store):
+    paths = _paths(tmp_path)
+    _write(paths["state_path"], ["not", "a", "dict"])
+    report = migrate_json_history(tmp_path, store, **paths)
+    assert report.comments == 0
+
+
+def test_state_without_comment_history(tmp_path, store):
+    paths = _paths(tmp_path)
+    _write(paths["state_path"], {"last_check": 123})
+    assert migrate_json_history(tmp_path, store, **paths).comments == 0
+
+
+# -- report ------------------------------------------------------------------
+
+def test_report_summary_mentions_every_collection():
+    report = MigrationReport(comments=2, improvements=3, knowledge=4)
+    summary = report.summary()
+    assert "2 comments" in summary
+    assert "3 improvements" in summary
+    assert "4 knowledge entries" in summary
+    assert report.total == 9
+
+
+def test_report_summary_mentions_skipped_records():
+    report = MigrationReport(skipped=["bad record"])
+    assert "1 records skipped" in report.summary()
+
+
+# -- the collections are actually cut over, not just snapshotted -------------
+
+def test_comments_written_after_startup_are_visible_to_readers(tmp_path, monkeypatch):
+    """A backfill that nothing reads or writes is a stale snapshot, not a
+    migration -- it leaves two sources of truth."""
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+    moltbook.record_comment(state, {"ts": 1.0, "post_id": "p1", "comment": "written now"})
+    moltbook.save_state(state)
+
+    # A fresh load, as the next cycle would do.
+    reloaded = moltbook.load_state()
+    assert [c["comment"] for c in reloaded["comment_history"]] == ["written now"]
+
+
+def test_comment_history_is_no_longer_persisted_in_state_json(tmp_path, monkeypatch):
+    """102 KB of a 169 KB file, rewritten every cycle."""
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+    moltbook.record_comment(state, {"ts": 1.0, "post_id": "p1", "comment": "x"})
+    moltbook.save_state(state)
+
+    assert "comment_history" not in _json.loads(state_file.read_text())
+
+
+def test_legacy_comments_in_state_json_are_imported(tmp_path, monkeypatch):
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_history": [{"ts": 1.0, "post_id": "p1", "comment": "legacy"}],
+        "last_check": 123,
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+
+    assert [c["comment"] for c in state["comment_history"]] == ["legacy"]
+    assert state["last_check"] == 123
+
+
+def test_knowledge_entries_written_after_startup_are_visible(tmp_path):
+    from ouroboros.knowledge_base import add_entries, load_kb
+
+    path = str(tmp_path / "kb.json")
+    add_entries([{"ts": 1, "insight": "written now"}], path)
+
+    assert [e["insight"] for e in load_kb(path)["entries"]] == ["written now"]
+
+
+def test_improvements_written_after_startup_are_visible(tmp_path):
+    from ouroboros.evaluation import EvaluationRecord, load_history
+    from ouroboros.storage import OuroborosStorage
+
+    record = EvaluationRecord(
+        task_id="t1", task_type="fix_bug", description="d",
+        outcome="success", timestamp=1.0,
+    )
+    OuroborosStorage(
+        db_path=tmp_path / "config" / "ouroboros.db"
+    ).append_improvement(record.to_dict())
+
+    assert [r.task_id for r in load_history(tmp_path)] == ["t1"]
+
+
+# -- the rollback story has to actually be true ------------------------------
+
+def test_state_json_legacy_comments_survive_the_first_save(tmp_path, monkeypatch):
+    """save_state stops writing comment_history, so without a snapshot the
+    first normal cycle would erase the pre-cutover comments it claims to
+    preserve for rollback."""
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_history": [{"ts": 1.0, "post_id": "p1", "comment": "legacy"}],
+        "last_check": 1,
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+    moltbook.save_state(state)
+
+    assert "comment_history" not in _json.loads(state_file.read_text())
+    snapshot = _json.loads((tmp_path / "state.json.pre-sqlite").read_text())
+    assert [c["comment"] for c in snapshot["comment_history"]] == ["legacy"]
+
+
+def test_knowledge_json_legacy_entries_survive_a_summary_refresh(tmp_path):
+    """save_kb writes only the cache, so the next refresh would drop them."""
+    import json as _json
+
+    from ouroboros.knowledge_base import load_kb, save_kb
+
+    kb_file = tmp_path / "kb.json"
+    kb_file.write_text(_json.dumps({
+        "entries": [{"ts": 1, "insight": "legacy"}],
+        "summary_cache": "", "summary_updated_at": 0,
+    }))
+
+    kb = load_kb(str(kb_file))
+    save_kb({"summary_cache": "new", "summary_updated_at": 2}, str(kb_file))
+
+    assert "entries" not in _json.loads(kb_file.read_text())
+    snapshot = _json.loads((tmp_path / "kb.json.pre-sqlite").read_text())
+    assert [e["insight"] for e in snapshot["entries"]] == ["legacy"]
+
+
+def test_snapshot_is_taken_once_and_not_overwritten(tmp_path, store):
+    from ouroboros.state_migration import freeze_rollback_snapshot
+
+    source = tmp_path / "state.json"
+    source.write_text('{"original": true}')
+
+    freeze_rollback_snapshot(source)
+    source.write_text('{"changed": true}')
+    freeze_rollback_snapshot(source)
+
+    assert (tmp_path / "state.json.pre-sqlite").read_text() == '{"original": true}'
+
+
+def test_snapshot_of_a_missing_file_is_a_no_op(tmp_path):
+    from ouroboros.state_migration import freeze_rollback_snapshot
+
+    assert freeze_rollback_snapshot(tmp_path / "nope.json") is None
+
+
+# -- a public comment must not be lost if the database write fails -----------
+
+def test_a_comment_survives_a_storage_failure(tmp_path, monkeypatch):
+    """The comment is already public; save_state drops the in-memory list, so
+    without an outbox the local record would be gone after a restart."""
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+
+    class Broken:
+        def append_comment(self, entry):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(moltbook, "_comment_storage", lambda: Broken())
+    moltbook.record_comment(state, {"ts": 1.0, "post_id": "p1", "comment": "posted"})
+    moltbook.save_state(state)
+
+    # It is queued in the file that does get written.
+    import json as _json
+    assert _json.loads(state_file.read_text())["comment_outbox"][0]["comment"] == "posted"
+
+
+def test_the_outbox_is_drained_on_the_next_load(tmp_path, monkeypatch):
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_outbox": [{"ts": 1.0, "post_id": "p1", "comment": "recovered"}],
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+
+    assert state["comment_outbox"] == []
+    assert [c["comment"] for c in state["comment_history"]] == ["recovered"]
+
+
+def test_both_knowledge_import_paths_agree_on_identity(tmp_path, store):
+    """load_kb and the startup migration both import legacy entries. Different
+    fingerprints would mean whichever runs second inserts them again."""
+    import json as _json
+
+    from ouroboros.knowledge_base import load_kb
+
+    kb_file = tmp_path / "kb.json"
+    kb_file.write_text(_json.dumps({"entries": [{"ts": 1, "insight": "shared"}]}))
+
+    load_kb(str(kb_file))
+    migrate_json_history(tmp_path, kb_path=kb_file, state_path=tmp_path / "none.json",
+                         history_path=tmp_path / "none2.json")
+
+    from ouroboros.storage import OuroborosStorage
+    assert OuroborosStorage().knowledge_count() == 1
+
+
+# -- failure injection: no cutover without a durable rollback artifact -------
+
+def test_no_comment_cutover_without_a_snapshot(tmp_path, monkeypatch):
+    """Stripping the list from state.json with no snapshot would erase it."""
+    import json as _json
+
+    from ouroboros import moltbook, state_migration
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_history": [{"ts": 1.0, "post_id": "p1", "comment": "legacy"}],
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+    monkeypatch.setattr(state_migration, "freeze_rollback_snapshot", lambda p: None)
+
+    state = moltbook.load_state()
+    moltbook.save_state(state)
+
+    # The legacy list is still authoritative in the file.
+    assert _json.loads(state_file.read_text())["comment_history"][0]["comment"] == "legacy"
+
+
+def test_no_comment_cutover_when_a_record_fails_to_import(tmp_path, monkeypatch):
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_history": [
+            {"ts": 1.0, "post_id": "good", "comment": "a"},
+            {"ts": 2.0, "post_id": "bad", "comment": "b"},
+        ],
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    real = moltbook._comment_storage()
+
+    class Flaky:
+        def comment_count(self):
+            return real.comment_count()
+
+        def get_comment_history(self, limit=None):
+            return real.get_comment_history(limit)
+
+        def append_comment(self, entry):
+            if entry.get("post_id") == "bad":
+                raise OSError("disk full")
+            return real.append_comment(entry)
+
+    monkeypatch.setattr(moltbook, "_comment_storage", lambda: Flaky())
+
+    state = moltbook.load_state()
+    moltbook.save_state(state)
+
+    assert len(_json.loads(state_file.read_text())["comment_history"]) == 2
+
+
+def test_no_knowledge_cutover_without_a_snapshot(tmp_path, monkeypatch):
+    import json as _json
+
+    from ouroboros import state_migration
+    from ouroboros.knowledge_base import load_kb, save_kb
+
+    kb_file = tmp_path / "kb.json"
+    kb_file.write_text(_json.dumps({"entries": [{"ts": 1, "insight": "legacy"}]}))
+    monkeypatch.setattr(state_migration, "freeze_rollback_snapshot", lambda p: None)
+
+    kb = load_kb(str(kb_file))
+
+    assert [e["insight"] for e in kb["entries"]] == ["legacy"]
+    assert _json.loads(kb_file.read_text())["entries"], "file still authoritative"
+
+
+def test_a_partial_snapshot_is_not_accepted(tmp_path):
+    from ouroboros.state_migration import freeze_rollback_snapshot
+
+    source = tmp_path / "state.json"
+    source.write_text('{"real": true}')
+    (tmp_path / "state.json.pre-sqlite").write_text("")  # truncated
+
+    snapshot = freeze_rollback_snapshot(source)
+
+    assert snapshot is not None
+    assert snapshot.read_text() == '{"real": true}'
+
+
+def test_a_failed_comment_write_is_durable_immediately(tmp_path, monkeypatch):
+    """A crash before the cycle-end save must not lose an already-public
+    comment."""
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+    state = moltbook.load_state()
+
+    class Broken:
+        def append_comment(self, entry):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(moltbook, "_comment_storage", lambda: Broken())
+    moltbook.record_comment(state, {"ts": 1.0, "post_id": "p1", "comment": "posted"})
+
+    # No save_state call here -- the process "crashes" right after.
+    on_disk = _json.loads(state_file.read_text())
+    assert on_disk["comment_outbox"][0]["comment"] == "posted"
+
+
+def test_a_knowledge_batch_is_all_or_nothing(tmp_path):
+    """Per-entry commits leave half a batch written after a mid-batch failure,
+    and the caller has already marked those posts seen."""
+    from ouroboros.storage import OuroborosStorage
+
+    store = OuroborosStorage(db_path=tmp_path / "kb.db")
+    pairs = [({"insight": f"i{i}"}, f"fp{i}") for i in range(3)]
+    assert store.append_knowledge_batch(pairs) == 3
+    assert store.knowledge_count() == 3
+
+    # Re-inserting the same batch adds nothing.
+    assert store.append_knowledge_batch(pairs) == 0
+    assert store.knowledge_count() == 3
+
+
+def test_a_partial_import_is_not_treated_as_complete_after_restart(tmp_path, monkeypatch):
+    """Inferring completion from a non-empty table loses the rest.
+
+    One successful insert makes count() non-zero, so a count-based guard would
+    skip the remaining legacy records on the next start and then strip the
+    file that still held them.
+    """
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_history": [
+            {"ts": 1.0, "post_id": "good", "comment": "a"},
+            {"ts": 2.0, "post_id": "bad", "comment": "b"},
+        ],
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    real = moltbook._comment_storage()
+    fail_on_bad = {"active": True}
+
+    class Flaky:
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+        def append_comment(self, entry):
+            if fail_on_bad["active"] and entry.get("post_id") == "bad":
+                raise OSError("disk full")
+            return real.append_comment(entry)
+
+    monkeypatch.setattr(moltbook, "_comment_storage", lambda: Flaky())
+
+    # First start: "good" imports, "bad" fails, cutover abandoned.
+    moltbook.save_state(moltbook.load_state())
+    assert len(_json.loads(state_file.read_text())["comment_history"]) == 2
+
+    # Second start, still failing: the table is non-empty now, but the file
+    # must still be authoritative.
+    moltbook.save_state(moltbook.load_state())
+    assert len(_json.loads(state_file.read_text())["comment_history"]) == 2
+
+    # Third start, disk recovered: the import completes and only now is the
+    # file stripped.
+    fail_on_bad["active"] = False
+    state = moltbook.load_state()
+    moltbook.save_state(state)
+    assert "comment_history" not in _json.loads(state_file.read_text())
+    assert len(state["comment_history"]) == 2, "both records survived"
+
+
+def test_a_completed_migration_is_not_repeated(tmp_path, monkeypatch):
+    """Once marked done, a stale legacy list must not be re-imported."""
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "comment_history": [{"ts": 1.0, "post_id": "p1", "comment": "legacy"}],
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    moltbook.save_state(moltbook.load_state())
+    # Someone restores an old state.json over the top.
+    state_file.write_text(_json.dumps({
+        "comment_history": [{"ts": 1.0, "post_id": "p1", "comment": "legacy"}],
+    }))
+    state = moltbook.load_state()
+
+    assert len(state["comment_history"]) == 1
+
+
+def test_a_failed_knowledge_batch_is_queued_not_lost(tmp_path, monkeypatch):
+    """The source posts are already in seen_post_ids, so a lost batch is never
+    regenerated -- later cycles skip those posts."""
+    import json as _json
+
+    from ouroboros import moltbook
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+    state = moltbook.load_state()
+
+    monkeypatch.setattr(
+        "ouroboros.knowledge_base.add_entries",
+        lambda entries, path=None: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    moltbook._record_knowledge(state, [{"insight": "would be lost", "ts": 1}])
+
+    on_disk = _json.loads(state_file.read_text())
+    assert on_disk["knowledge_outbox"][0]["insight"] == "would be lost"
+
+
+def test_a_queued_knowledge_batch_is_retried(tmp_path, monkeypatch):
+    import json as _json
+
+    from ouroboros import moltbook
+    from ouroboros.knowledge_base import load_kb
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(_json.dumps({
+        "knowledge_outbox": [{"insight": "recovered", "ts": 1}],
+    }))
+    monkeypatch.setattr(moltbook, "_state_path", lambda: str(state_file))
+
+    state = moltbook.load_state()
+
+    assert state["knowledge_outbox"] == []
+    assert [e["insight"] for e in load_kb(str(tmp_path / "kb.json"))["entries"]] == [
+        "recovered",
+    ]
+
+
+def test_partial_improvement_import_is_retried_after_restart(tmp_path, monkeypatch):
+    """Same inference bug as the other two collections: one successful insert
+    would make a count-based check treat the import as finished."""
+    import json as _json
+
+    from ouroboros import evaluation as ev
+
+    hist = tmp_path / "config" / "improvement_history.json"
+    hist.parent.mkdir(parents=True)
+    hist.write_text(_json.dumps([
+        {"task_id": "good", "timestamp": 1.0, "outcome": "success",
+         "task_type": "fix_bug", "description": "d", "test_delta": {},
+         "pr_url": "", "feedback": ""},
+        {"task_id": "bad", "timestamp": 2.0, "outcome": "success",
+         "task_type": "fix_bug", "description": "d", "test_delta": {},
+         "pr_url": "", "feedback": ""},
+    ]))
+
+    real = ev._history_storage(tmp_path)
+    failing = {"active": True}
+
+    class Flaky:
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+        def append_improvement(self, record):
+            if failing["active"] and record.get("task_id") == "bad":
+                raise OSError("locked")
+            return real.append_improvement(record)
+
+    monkeypatch.setattr(ev, "_history_storage", lambda root=None: Flaky())
+
+    assert len(ev.load_history(tmp_path)) == 1        # partial
+    assert not real.migration_done("improvement_history_v1")
+
+    failing["active"] = False
+    assert len(ev.load_history(tmp_path)) == 2        # retried and completed
+    assert real.migration_done("improvement_history_v1")
+
+
+def test_a_failed_improvement_write_falls_back_to_json(tmp_path, monkeypatch):
+    """The PR already exists; the record must not be lost."""
+    import json as _json
+
+    from ouroboros import evaluation as ev
+    from ouroboros.improvement import ImprovementResult, ImprovementTask
+
+    hist = tmp_path / "config" / "improvement_history.json"
+    hist.parent.mkdir(parents=True)
+    hist.write_text("[]")
+
+    real = ev._history_storage(tmp_path)
+
+    class Broken:
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+        def append_improvement(self, record):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(ev, "_history_storage", lambda root=None: Broken())
+
+    task = ImprovementTask("t1", "fix_bug", "d", [], "e")
+    ev.record_improvement(
+        ImprovementResult(task=task, status="success", pr_url="https://x/1"),
+        tmp_path,
+    )
+
+    persisted = _json.loads(hist.read_text())
+    assert [r["task_id"] for r in persisted] == ["t1"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -448,3 +448,135 @@ def test_save_leaves_a_git_repository_clean(tmp_path):
     stray = [p for p in status if p not in {"??", "config/backlog.json",
                                             "config/improvement_history.json"}]
     assert stray == [], f"save left files git would flag: {stray}"
+
+
+# -- append-only history -----------------------------------------------------
+
+def test_append_comment_round_trip(store):
+    record = {"ts": 1.0, "post_id": "p1", "comment_id": "c1", "comment": "hello",
+              "title": "T", "extra": {"nested": True}}
+    assert store.append_comment(record) is True
+    assert store.get_comment_history() == [record]
+
+
+def test_append_comment_is_idempotent(store):
+    record = {"ts": 1.0, "post_id": "p1", "comment": "hello"}
+    assert store.append_comment(record) is True
+    assert store.append_comment(record) is False
+    assert store.comment_count() == 1
+
+
+def test_append_comment_dedupes_with_a_null_comment_id(store):
+    """SQLite treats each NULL as distinct, so a UNIQUE over nullable columns
+    would not dedupe -- every historical record has comment_id null."""
+    record = {"ts": 1.0, "post_id": "p1", "comment_id": None, "comment": "hello"}
+    store.append_comment(record)
+    store.append_comment(dict(record))
+    assert store.comment_count() == 1
+
+
+def test_different_comments_on_one_post_are_distinct(store):
+    store.append_comment({"ts": 1.0, "post_id": "p1", "comment": "first"})
+    store.append_comment({"ts": 2.0, "post_id": "p1", "comment": "second"})
+    assert store.comment_count() == 2
+
+
+def test_comment_history_is_in_append_order_not_timestamp_order(store):
+    """The JSON lists were append-ordered and callers slice them with [-n:].
+
+    Sorting by ts would reorder history after a clock correction, and change
+    which records "the last 20 comments" selects.
+    """
+    for ts in (3.0, 1.0, 2.0):
+        store.append_comment({"ts": ts, "post_id": f"p{ts}", "comment": "x"})
+    assert [c["ts"] for c in store.get_comment_history()] == [3.0, 1.0, 2.0]
+
+
+def test_comment_history_order_survives_a_clock_regression(store):
+    store.append_comment({"ts": 100.0, "post_id": "p1", "comment": "first"})
+    store.append_comment({"ts": 5.0, "post_id": "p2", "comment": "after ntp fixed the clock"})
+    assert [c["comment"] for c in store.get_comment_history()] == [
+        "first", "after ntp fixed the clock",
+    ]
+
+
+def test_comment_history_limit_returns_the_newest_oldest_first(store):
+    """Callers used to slice the JSON list with [-n:]."""
+    for ts in range(1, 6):
+        store.append_comment({"ts": float(ts), "post_id": f"p{ts}", "comment": "x"})
+    assert [c["ts"] for c in store.get_comment_history(limit=2)] == [4.0, 5.0]
+
+
+def test_a_zero_timestamp_is_stored_as_zero(store):
+    """`value or time.time()` would silently replace it with now."""
+    store.append_comment({"ts": 0.0, "post_id": "p0", "comment": "oldest"})
+    with sqlite3.connect(store.db_path) as conn:
+        assert conn.execute("SELECT ts FROM comment_history").fetchone()[0] == 0.0
+
+
+@pytest.mark.parametrize("bad_ts", [None, "not a number", {}])
+def test_an_unusable_timestamp_falls_back_to_now(store, bad_ts):
+    store.append_comment({"ts": bad_ts, "post_id": "p1", "comment": "x"})
+    assert store.get_comment_history()[0]["comment"] == "x"
+
+
+def test_append_improvement_round_trip(store):
+    record = {"task_id": "t1", "timestamp": 1.0, "outcome": "success",
+              "description": "d"}
+    assert store.append_improvement(record) is True
+    assert store.get_improvement_history() == [record]
+
+
+def test_append_improvement_is_idempotent(store):
+    record = {"task_id": "t1", "timestamp": 1.0, "outcome": "success"}
+    store.append_improvement(record)
+    assert store.append_improvement(record) is False
+    assert store.improvement_count() == 1
+
+
+def test_update_improvement_rewrites_one_row(store):
+    store.append_improvement({"task_id": "t1", "timestamp": 1.0, "outcome": "success"})
+    store.append_improvement({"task_id": "t2", "timestamp": 2.0, "outcome": "success"})
+
+    assert store.update_improvement(
+        "t1", 1.0, {"task_id": "t1", "timestamp": 1.0, "outcome": "merged"}
+    ) is True
+
+    outcomes = {r["task_id"]: r["outcome"] for r in store.get_improvement_history()}
+    assert outcomes == {"t1": "merged", "t2": "success"}
+
+
+def test_update_improvement_reports_a_miss(store):
+    assert store.update_improvement("nope", 1.0, {"outcome": "merged"}) is False
+
+
+def test_append_knowledge_dedupes_on_fingerprint(store):
+    entry = {"insight": "a"}
+    assert store.append_knowledge(entry, "fp1") is True
+    assert store.append_knowledge(entry, "fp1") is False
+    assert store.knowledge_count() == 1
+
+
+def test_history_survives_reopening(tmp_path):
+    db = tmp_path / "ouroboros.db"
+    OuroborosStorage(db_path=db).append_comment({"ts": 1.0, "post_id": "p", "comment": "x"})
+    assert OuroborosStorage(db_path=db).comment_count() == 1
+
+
+def test_an_unreadable_row_is_skipped_not_fatal(store):
+    """A hand-corrupted payload must not take out the whole read."""
+    store.append_comment({"ts": 1.0, "post_id": "p1", "comment": "good"})
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute(
+            "INSERT INTO comment_history (ts, post_id, fingerprint, payload) "
+            "VALUES (2.0, 'p2', 'fp', 'not json')"
+        )
+
+    assert [c["comment"] for c in store.get_comment_history()] == ["good"]
+
+
+def test_record_fingerprint_is_stable_and_distinguishing():
+    fp = OuroborosStorage.record_fingerprint
+    assert fp("a", "b") == fp("a", "b")
+    assert fp("a", "b") != fp("b", "a")
+    assert fp("a", None) != fp("a", "")


### PR DESCRIPTION
Closes #12.

`state.json` was **169 KB, and 85% of it was append-only lists** read and rewritten in full every cycle — `comment_history` alone was 102 KB. `improvement_history.json` was another 43 KB, rewritten on every improvement and again on every PR poll.

The cost wasn't only the rewriting. Because the files had to stay small enough to load, each list carried a cap — 100 comments, 200 knowledge entries — so **the agent was continuously discarding its own history** to stay under them.

Three tables, appends are O(1), nothing is capped. On the real data: **state.json 172 KB → 66 KB**, with all 80 comments and 61 improvements preserved.

## All three are genuinely cut over

Not merely copied — a backfilled table that nothing reads or writes is two sources of truth and a snapshot that goes stale on the first new record. There's a test per collection asserting a post-startup write is visible to the normal readers.

- **evaluation** appends one row instead of rewriting the file; `check_pr_outcomes` updates one row instead of all.
- **knowledge_base** keeps its public API; only the two-field summary cache stays in JSON.
- **moltbook** hydrates a recent comment window in `load_state` and writes via `record_comment`, so readers that slice `state["comment_history"]` are unchanged while `save_state` stops persisting the list.

## Safety is most of this change

Nothing is dropped from a JSON file until its records are known to be in the database.

**Completion is an explicit marker row, never inferred from a non-empty table.** One successful insert would otherwise make a partial import look finished, and the next start would skip the remaining records and *then* strip the file that still held them. Tested across three restarts with the failure clearing on the third.

**Snapshots before anything destructive.** `state.json` and `knowledge_base.json` keep being written after the cutover, so each is copied to `<name>.pre-sqlite` — via temp file and atomic rename, since a truncated snapshot that merely *exists* is worse than none. A failed snapshot abandons the cutover for that cycle. Verified both ways:

```
normal cutover   in-file=  0  snapshot= 80  -> 80 recoverable
snapshot fails   in-file= 80  snapshot=  0  -> 80 recoverable
```

**Writes that can't be lost.** A comment is already public when recorded, so a failed DB write is queued and state written *immediately*, not at cycle end. Knowledge batches insert in one transaction and queue on failure, since the source posts are already marked seen. A failed improvement write falls back to the legacy JSON and clears the marker so the next read re-imports.

**Ordering is by insertion, not timestamp** — callers slice with `[-n:]`, and sorting by `ts` would reshuffle history whenever the Pi's clock was corrected.

**Identity is a content fingerprint.** `comment_id` is null on all 80 records and SQLite treats every NULL as distinct, so `UNIQUE (post_id, comment_id)` deduped *nothing* — a second migration run re-inserted all 80. That's how it was found.

## Downgrading

Deploy the previous version, then take `comment_history` from `state.json.pre-sqlite` and `entries` from `knowledge_base.json.pre-sqlite`. Those are pre-cutover, so they hold neither records written since nor current runtime pointers — restoring a whole snapshot over a live file would rewind `seen_post_ids` and the cycle timestamps with it. Post-cutover records live only in SQLite. That's the inherent cost of a cutover, stated rather than papered over.

## Also fixed

`OuroborosStorage()` with no path resolves to the **live** `config/ouroboros.db`, and tests were writing to it — two stray records reached the real database. A conftest fixture now redirects the default into `tmp_path`. Also: a timestamp of `0.0` was treated as missing via `value or time.time()`.

## Verification

`774 passed` locally, 3.10–3.14 in CI. Against the real data: 80 comments and 61 improvements migrate, repeat runs add nothing, order matches the JSON exactly.

## Not fixed here

Feed posts are marked seen before knowledge extraction, so uncommented posts past the per-cycle extraction bound are never considered. That predates this change and is feed-ingestion, not storage — filed as #67.

## Review

Codex, seven rounds — the most adversarial of this series, appropriately for a live-state cutover. It found that my first version had only actually migrated `improvement_history` (the other two were dead snapshots), that the JSON files I called the rollback path were destroyed by the first ordinary save, and that count-based completion checks turn a partial import into silent loss on restart. Each was reproduced before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AP3jnpPXHVQrUBZPE17Gm