### PR TITLE
fix(config): one schema for what a config field may hold (#63, #54)

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,19 @@
+---
+stage: maintaining
+---
+
+Self-improving autonomous agent on Raspberry Pi — iteratively commits improvements to its own codebase using Claude.
+
+## Current
+The README presents Ouroboros as a running autonomous agent with a stable Raspberry Pi deployment model and most detailed documentation moved to the GitHub wiki. Top-level docs do not show the current live health or recent improvement cadence.
+
+## Next
+Run the Pi health check and record any drift between the live agent and the documented setup.
+
+## Milestone
+**What:** Pi health check + drift audit
+**Target:** 2026-05-31
+- [ ] SSH to Pi and confirm last successful run
+- [ ] Pull metrics: success rate, revert rate over last 30 days
+- [ ] Diff live config against repo defaults
+- [ ] Check failure-pattern docs are up to date

--- a/src/ouroboros/cli.py
+++ b/src/ouroboros/cli.py
@@ -100,7 +100,10 @@ def cmd_config_modify(args: argparse.Namespace) -> int:
             return 1
         key, raw = kv.split("=", 1)
 
-        parsed, error = config_schema.parse_value(key, raw)
+        error = config_schema.settable_error(key)
+        parsed = None
+        if error is None:
+            parsed, error = config_schema.parse_value(key, raw)
         if error is None:
             error = config_schema.validate(key, parsed)
         if error:

--- a/src/ouroboros/cli.py
+++ b/src/ouroboros/cli.py
@@ -86,86 +86,31 @@ def cmd_config_show(_args: argparse.Namespace) -> int:
     return 0
 
 
-def _int_config_fields() -> set:
-    """Names of RunnerConfig fields typed int.
-
-    Read from the dataclass rather than hardcoded, so a field added later is
-    covered without anyone remembering to update a list here.
-    """
-    from dataclasses import fields as dataclass_fields
-
-    from .moltbook import RunnerConfig
-
-    return {f.name for f in dataclass_fields(RunnerConfig) if f.type in ("int", int)}
-
-
-def _parse_config_value(value: str) -> Any:
-    """Coerce a command-line value to bool, int, or str.
-
-    Deliberately no float: RunnerConfig has nineteen int fields and no float
-    ones, so a fractional value is always wrong for the field it is aimed at.
-    Coercing it would be worse than leaving it a string -- load_runner_config
-    calls int() on those fields, and int(0.5) is 0, which turns a typo into a
-    loop that never sleeps. _validate_config_update rejects it instead.
-    """
-    if value.lower() == "true":
-        return True
-    if value.lower() == "false":
-        return False
-    try:
-        return int(value)
-    except ValueError:
-        return value
-
-
-def _validate_config_update(key: str, value: str) -> Optional[str]:
-    """Return an error message for a value that would break the loader.
-
-    Narrow on purpose: only the cases that stop the agent starting or remove
-    its rate limiting. Full schema validation -- unknown keys, ranges -- is
-    tracked separately.
-    """
-    int_fields = _int_config_fields()
-
-    if not value.strip():
-        if key in int_fields:
-            # load_runner_config calls int("") and raises, so the agent will
-            # not start until someone edits the file by hand.
-            return f"{key} is numeric and cannot be empty"
-        # Empty is meaningful for the string fields: reviewer_base_url,
-        # reviewer_model and generator_model all use it to mean "unset", and
-        # clearing a compromised reviewer endpoint has to be possible here.
-        return None
-
-    if key in int_fields:
-        try:
-            parsed = int(value)
-        except ValueError:
-            return f"{key} must be a whole number, got {value!r}"
-        if parsed <= 0:
-            # int() accepts these; the loop then sleeps for zero or negative
-            # seconds and hammers every dependency it has.
-            return f"{key} must be positive, got {parsed}"
-
-    return None
-
-
 def cmd_config_modify(args: argparse.Namespace) -> int:
     if not can_self_modify():
         print("Self-modification is disabled. Set allow_self_modification=True in SafetyConfig.")
         return 2
+
+    from . import config_schema
 
     updates = {}
     for kv in args.updates:
         if "=" not in kv:
             print(f"Invalid update format: {kv}. Use key=value")
             return 1
-        key, value = kv.split("=", 1)
-        error = _validate_config_update(key, value)
+        key, raw = kv.split("=", 1)
+
+        parsed, error = config_schema.parse_value(key, raw)
+        if error is None:
+            error = config_schema.validate(key, parsed)
         if error:
+            # Nothing is written: a later bad pair must not leave an earlier
+            # good one applied.
             print(f"Invalid update: {error}")
+            if key in config_schema.field_types():
+                print(f"  {key} takes {config_schema.describe(key)}")
             return 1
-        updates[key] = _parse_config_value(value)
+        updates[key] = parsed
 
     modify_runner_config(updates)
     redacted = dict(updates)

--- a/src/ouroboros/config_schema.py
+++ b/src/ouroboros/config_schema.py
@@ -1,0 +1,227 @@
+"""One description of what a RunnerConfig field may hold.
+
+Two callers need this and had been diverging: the operator CLI, which accepted
+any key and almost any value, and the comment-upgrade path, which decided what
+a stranger may change with a deny-list -- so every field added since was
+suggestible until someone remembered to list it.
+
+Field names and types come from the dataclass. Only the bounds are written
+down here, and only where a value is nonsensical rather than merely unusual.
+"""
+
+from dataclasses import fields as dataclass_fields
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+
+
+class Bounds(NamedTuple):
+    minimum: Optional[int] = None
+    maximum: Optional[int] = None
+
+
+# Ranges for numeric fields. A missing entry means "any positive integer",
+# which is the floor applied to every int field: the loop sleeps on most of
+# these, and zero or negative turns a typo into a busy loop.
+_BOUNDS: Dict[str, Bounds] = {
+    # Ceilings are sanity limits, not policy: a year of seconds, a day of
+    # hours. They exist so a fat-fingered value is refused rather than
+    # silently parking the agent for a decade.
+    "interval_seconds": Bounds(1, 31_536_000),
+    "min_comment_interval_seconds": Bounds(1, 31_536_000),
+    "telegram_error_min_interval_seconds": Bounds(1, 31_536_000),
+    "self_improvement_retry_minutes": Bounds(1, 525_600),
+    "comment_check_interval_hours": Bounds(1, 8_760),
+    "community_improvement_interval_hours": Bounds(1, 8_760),
+    "community_wait_hours": Bounds(1, 8_760),
+    "engagement_check_interval_hours": Bounds(1, 8_760),
+    "git_push_interval_hours": Bounds(1, 8_760),
+    "github_improvement_interval_hours": Bounds(1, 8_760),
+    "improvement_interval_hours": Bounds(1, 8_760),
+    "issue_scouting_interval_hours": Bounds(1, 8_760),
+    "min_post_interval_hours": Bounds(1, 8_760),
+    "self_improve_interval_hours": Bounds(1, 8_760),
+    "self_question_hours": Bounds(1, 8_760),
+    "wiki_update_interval_hours": Bounds(1, 8_760),
+    # A count of zero is meaningful here -- it means "do not comment" -- so
+    # these floor at 0 rather than 1.
+    "max_comments_per_cycle": Bounds(0, 100),
+    "community_min_comments_for_early": Bounds(0, 1_000),
+    # An hour of the day.
+    "oddities_digest_hour": Bounds(0, 23),
+}
+
+# Fields a public comment may suggest changing. An allowlist, not a deny-list:
+# a field added later is operator-only until someone deliberately opens it,
+# rather than suggestible until someone remembers to close it.
+#
+# Everything here is a rate or a threshold. Nothing that redirects traffic,
+# names a credential, chooses a model, or switches a capability on.
+COMMENT_SUGGESTIBLE_FIELDS = frozenset({
+    "interval_seconds",
+    "min_comment_interval_seconds",
+    "max_comments_per_cycle",
+    "min_post_interval_hours",
+    "self_question_hours",
+    "comment_check_interval_hours",
+    "improvement_interval_hours",
+    "community_wait_hours",
+    "community_min_comments_for_early",
+    "telegram_error_min_interval_seconds",
+})
+
+# Suggestions from a comment may only make the agent less active. An interval
+# can grow, a count can shrink. "Post less often" is reasonable advice from a
+# stranger; "poll ten times faster" is the thing the guard exists to prevent,
+# and this makes a hostile suggestion self-limiting rather than relying on the
+# bounds above to be tight enough.
+_LOWER_IS_MORE_ACTIVE = frozenset({
+    name for name in COMMENT_SUGGESTIBLE_FIELDS
+    if name.endswith(("_seconds", "_hours", "_minutes"))
+})
+
+
+# Accepted by `config modify` but not RunnerConfig fields: self_modify routes
+# them to credentials.json. ollama_api_key is the alias kept for the Ollama
+# Cloud reviewer setup.
+_CREDENTIAL_ALIASES: Dict[str, Any] = {"ollama_api_key": str}
+
+
+def field_types() -> Dict[str, Any]:
+    """Map every settable key to its declared type."""
+    from .moltbook import RunnerConfig
+
+    types: Dict[str, Any] = {f.name: f.type for f in dataclass_fields(RunnerConfig)}
+    types.update(_CREDENTIAL_ALIASES)
+    return types
+
+
+def _is_int_field(declared: Any) -> bool:
+    return declared in ("int", int)
+
+
+def _is_bool_field(declared: Any) -> bool:
+    return declared in ("bool", bool)
+
+
+def validate(key: str, value: Any) -> Optional[str]:
+    """Return an error message if key/value is not a valid config setting.
+
+    Unknown keys are rejected. A silently ignored typo is the worst outcome:
+    the command reports success and the setting never takes effect.
+    """
+    types = field_types()
+    if key not in types:
+        suggestion = _closest(key, types)
+        hint = f"; did you mean {suggestion}?" if suggestion else ""
+        return f"unknown setting {key!r}{hint}"
+
+    declared = types[key]
+
+    if _is_bool_field(declared):
+        if not isinstance(value, bool):
+            return f"{key} must be true or false"
+        return None
+
+    if _is_int_field(declared):
+        # bool is an int subclass, and `enable_x=true` for a numeric field is
+        # a mistake worth naming rather than storing as 1.
+        if isinstance(value, bool) or not isinstance(value, int):
+            return f"{key} must be a whole number, got {value!r}"
+        bounds = _BOUNDS.get(key, Bounds(1, None))
+        if bounds.minimum is not None and value < bounds.minimum:
+            return f"{key} must be at least {bounds.minimum}, got {value}"
+        if bounds.maximum is not None and value > bounds.maximum:
+            return f"{key} must be at most {bounds.maximum}, got {value}"
+        return None
+
+    # Strings and optional lists. Empty is meaningful for the string fields --
+    # reviewer_base_url, reviewer_model and generator_model use it to mean
+    # "unset", and clearing a compromised endpoint has to stay possible.
+    if isinstance(value, (str, list)) or value is None:
+        return None
+    return f"{key} must be text, got {value!r}"
+
+
+def validate_suggestion(key: str, value: Any, current: Any) -> Optional[str]:
+    """Validate a change proposed by a public comment.
+
+    Stricter than `validate`: restricted to the tuning allowlist, and only in
+    the direction that makes the agent less active.
+    """
+    if key not in COMMENT_SUGGESTIBLE_FIELDS:
+        return f"{key} may only be changed by an operator"
+
+    error = validate(key, value)
+    if error:
+        return error
+
+    if isinstance(current, int) and isinstance(value, int):
+        if key in _LOWER_IS_MORE_ACTIVE and value < current:
+            return f"{key} may only be increased by a suggestion ({current} -> {value})"
+        if key not in _LOWER_IS_MORE_ACTIVE and value > current:
+            return f"{key} may only be reduced by a suggestion ({current} -> {value})"
+
+    return None
+
+
+def _closest(key: str, known: Dict[str, Any]) -> Optional[str]:
+    """Best near-match for an unknown key, for the error message."""
+    import difflib
+
+    matches = difflib.get_close_matches(key, list(known), n=1, cutoff=0.7)
+    return matches[0] if matches else None
+
+
+def parse_value(key: str, raw: str) -> Tuple[Any, Optional[str]]:
+    """Coerce a command-line string to the type the field declares.
+
+    Typed by the field rather than guessed from the text, so `improvement_
+    interval_hours=true` is an error instead of being stored as a boolean, and
+    a model name that happens to look numeric stays a string.
+    """
+    types = field_types()
+    if key not in types:
+        return None, validate(key, raw)
+
+    declared = types[key]
+
+    if _is_bool_field(declared):
+        lowered = raw.strip().lower()
+        if lowered in ("true", "1", "yes", "on"):
+            return True, None
+        if lowered in ("false", "0", "no", "off"):
+            return False, None
+        return None, f"{key} must be true or false, got {raw!r}"
+
+    if _is_int_field(declared):
+        try:
+            return int(raw.strip()), None
+        except ValueError:
+            return None, f"{key} must be a whole number, got {raw!r}"
+
+    if "List" in str(declared):
+        items = [part.strip() for part in raw.split(",") if part.strip()]
+        return (items or None), None
+
+    return raw, None
+
+
+def describe(key: str) -> str:
+    """Human-readable description of what a field accepts."""
+    types = field_types()
+    if key not in types:
+        return "unknown setting"
+    declared = types[key]
+    if _is_bool_field(declared):
+        return "true or false"
+    if _is_int_field(declared):
+        bounds = _BOUNDS.get(key, Bounds(1, None))
+        if bounds.maximum is None:
+            return f"a whole number >= {bounds.minimum}"
+        return f"a whole number from {bounds.minimum} to {bounds.maximum}"
+    if "List" in str(declared):
+        return "a comma-separated list"
+    return "text"
+
+
+def settable_keys() -> List[str]:
+    return sorted(field_types())

--- a/src/ouroboros/config_schema.py
+++ b/src/ouroboros/config_schema.py
@@ -68,15 +68,43 @@ COMMENT_SUGGESTIBLE_FIELDS = frozenset({
     "telegram_error_min_interval_seconds",
 })
 
-# Suggestions from a comment may only make the agent less active. An interval
-# can grow, a count can shrink. "Post less often" is reasonable advice from a
-# stranger; "poll ten times faster" is the thing the guard exists to prevent,
-# and this makes a hostile suggestion self-limiting rather than relying on the
-# bounds above to be tight enough.
-_LOWER_IS_MORE_ACTIVE = frozenset({
-    name for name in COMMENT_SUGGESTIBLE_FIELDS
-    if name.endswith(("_seconds", "_hours", "_minutes"))
-})
+# Which direction makes the agent less active, stated per field rather than
+# inferred from the name. A suffix heuristic got community_min_comments_for_early
+# backwards: it reads as a count, but lowering it makes the agent act *sooner*.
+#
+# "increase" = a suggestion may only raise it; "decrease" = only lower it.
+_SUGGESTION_DIRECTION: Dict[str, str] = {
+    "interval_seconds": "increase",
+    "min_comment_interval_seconds": "increase",
+    "min_post_interval_hours": "increase",
+    "self_question_hours": "increase",
+    "comment_check_interval_hours": "increase",
+    "improvement_interval_hours": "increase",
+    "community_wait_hours": "increase",
+    "telegram_error_min_interval_seconds": "increase",
+    "max_comments_per_cycle": "decrease",
+    # Lowering this triggers community analysis earlier, so it is the
+    # more-active direction despite reading like a capacity count.
+    "community_min_comments_for_early": "increase",
+}
+
+# Ceilings for a public suggestion, much tighter than the operator ones. "Less
+# active" taken far enough is "stopped": the operator ceiling on
+# interval_seconds is a year, and a suggestion of that would park the agent
+# while passing the direction rule. Throttling alerts to a year would hide
+# that it had.
+_SUGGESTION_BOUNDS: Dict[str, Bounds] = {
+    "interval_seconds": Bounds(60, 21_600),                    # 1 min - 6 h
+    "min_comment_interval_seconds": Bounds(60, 86_400),        # 1 min - 1 day
+    "telegram_error_min_interval_seconds": Bounds(60, 86_400),
+    "min_post_interval_hours": Bounds(1, 168),                 # up to a week
+    "self_question_hours": Bounds(1, 168),
+    "comment_check_interval_hours": Bounds(1, 168),
+    "improvement_interval_hours": Bounds(1, 336),              # up to a fortnight
+    "community_wait_hours": Bounds(1, 336),
+    "max_comments_per_cycle": Bounds(0, 10),
+    "community_min_comments_for_early": Bounds(1, 50),
+}
 
 
 # Accepted by `config modify` but not RunnerConfig fields: self_modify routes
@@ -102,6 +130,30 @@ def _is_bool_field(declared: Any) -> bool:
     return declared in ("bool", bool)
 
 
+def _is_float_field(declared: Any) -> bool:
+    return declared in ("float", float)
+
+
+# Fields the loader ignores when their replacement is present, so writing one
+# reports success and changes nothing. Still real dataclass fields with real
+# defaults -- the value is valid, the write is what is futile.
+_SUPERSEDED = {"self_improve_interval_hours": "improvement_interval_hours"}
+
+
+def settable_error(key: str) -> Optional[str]:
+    """Return an error if this key cannot usefully be written, whatever its value.
+
+    Separate from `validate` because a superseded field still holds a valid
+    value; it is only *setting* it that silently does nothing.
+    """
+    if key in _SUPERSEDED:
+        return (
+            f"{key} is deprecated and ignored when "
+            f"{_SUPERSEDED[key]} is set; use {_SUPERSEDED[key]} instead"
+        )
+    return None
+
+
 def validate(key: str, value: Any) -> Optional[str]:
     """Return an error message if key/value is not a valid config setting.
 
@@ -119,6 +171,13 @@ def validate(key: str, value: Any) -> Optional[str]:
     if _is_bool_field(declared):
         if not isinstance(value, bool):
             return f"{key} must be true or false"
+        return None
+
+    if _is_float_field(declared):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return f"{key} must be a number, got {value!r}"
+        if value <= 0:
+            return f"{key} must be positive, got {value}"
         return None
 
     if _is_int_field(declared):
@@ -150,15 +209,25 @@ def validate_suggestion(key: str, value: Any, current: Any) -> Optional[str]:
     if key not in COMMENT_SUGGESTIBLE_FIELDS:
         return f"{key} may only be changed by an operator"
 
-    error = validate(key, value)
+    error = settable_error(key) or validate(key, value)
     if error:
         return error
 
-    if isinstance(current, int) and isinstance(value, int):
-        if key in _LOWER_IS_MORE_ACTIVE and value < current:
+    direction = _SUGGESTION_DIRECTION.get(key)
+    if direction and isinstance(current, int) and isinstance(value, int):
+        if direction == "increase" and value < current:
             return f"{key} may only be increased by a suggestion ({current} -> {value})"
-        if key not in _LOWER_IS_MORE_ACTIVE and value > current:
+        if direction == "decrease" and value > current:
             return f"{key} may only be reduced by a suggestion ({current} -> {value})"
+
+    bounds = _SUGGESTION_BOUNDS.get(key)
+    if bounds and isinstance(value, int) and not isinstance(value, bool):
+        if bounds.minimum is not None and value < bounds.minimum:
+            return f"{key} may not be set below {bounds.minimum} by a suggestion"
+        if bounds.maximum is not None and value > bounds.maximum:
+            # "Less active" taken far enough is "stopped". The direction rule
+            # alone would wave through interval_seconds=31536000.
+            return f"{key} may not be set above {bounds.maximum} by a suggestion"
 
     return None
 
@@ -192,6 +261,12 @@ def parse_value(key: str, raw: str) -> Tuple[Any, Optional[str]]:
             return False, None
         return None, f"{key} must be true or false, got {raw!r}"
 
+    if _is_float_field(declared):
+        try:
+            return float(raw.strip()), None
+        except ValueError:
+            return None, f"{key} must be a number, got {raw!r}"
+
     if _is_int_field(declared):
         try:
             return int(raw.strip()), None
@@ -213,6 +288,8 @@ def describe(key: str) -> str:
     declared = types[key]
     if _is_bool_field(declared):
         return "true or false"
+    if _is_float_field(declared):
+        return "a positive number"
     if _is_int_field(declared):
         bounds = _BOUNDS.get(key, Bounds(1, None))
         if bounds.maximum is None:

--- a/src/ouroboros/config_schema.py
+++ b/src/ouroboros/config_schema.py
@@ -93,16 +93,24 @@ _SUGGESTION_DIRECTION: Dict[str, str] = {
 # interval_seconds is a year, and a suggestion of that would park the agent
 # while passing the direction rule. Throttling alerts to a year would hide
 # that it had.
+# The rule: a suggestion may throttle, but never past the point where the
+# operator loses visibility or the agent loses the ability to receive the next
+# correction. Comments are the channel a bad suggestion gets undone through,
+# so throttling that channel has to stay bounded well inside a working day.
 _SUGGESTION_BOUNDS: Dict[str, Bounds] = {
     "interval_seconds": Bounds(60, 21_600),                    # 1 min - 6 h
-    "min_comment_interval_seconds": Bounds(60, 86_400),        # 1 min - 1 day
-    "telegram_error_min_interval_seconds": Bounds(60, 86_400),
+    "min_comment_interval_seconds": Bounds(60, 21_600),
+    # Alerts are the operator's window onto all of the above.
+    "telegram_error_min_interval_seconds": Bounds(60, 3_600),
     "min_post_interval_hours": Bounds(1, 168),                 # up to a week
     "self_question_hours": Bounds(1, 168),
-    "comment_check_interval_hours": Bounds(1, 168),
-    "improvement_interval_hours": Bounds(1, 336),              # up to a fortnight
-    "community_wait_hours": Bounds(1, 336),
-    "max_comments_per_cycle": Bounds(0, 10),
+    # How often suggestions are read at all -- including the one undoing this.
+    "comment_check_interval_hours": Bounds(1, 24),
+    "improvement_interval_hours": Bounds(1, 168),
+    "community_wait_hours": Bounds(1, 168),
+    # Floors at 1, not 0: the operator meaning of 0 is "do not comment", and a
+    # stranger silencing the agent outright is not a throttle.
+    "max_comments_per_cycle": Bounds(1, 10),
     "community_min_comments_for_early": Bounds(1, 50),
 }
 
@@ -200,6 +208,26 @@ def validate(key: str, value: Any) -> Optional[str]:
     return f"{key} must be text, got {value!r}"
 
 
+def coerce_suggestion(key: str, value: Any) -> Tuple[Any, Optional[str]]:
+    """Bring a JSON value from a comment to the type the field declares.
+
+    A model writes "600" or 600.0 as readily as 600. Left alone these are not
+    merely rejected: an int field holding a str is uncomparable, so the
+    direction rule below would skip rather than fail. Coerce first, then the
+    guard has something to compare.
+    """
+    types = field_types()
+    if key not in types:
+        return value, None  # validate_suggestion names the real problem
+
+    declared = types[key]
+    if isinstance(value, str) and not _is_bool_field(declared):
+        return parse_value(key, value)
+    if _is_int_field(declared) and isinstance(value, float) and value.is_integer():
+        return int(value), None
+    return value, None
+
+
 def validate_suggestion(key: str, value: Any, current: Any) -> Optional[str]:
     """Validate a change proposed by a public comment.
 
@@ -214,7 +242,12 @@ def validate_suggestion(key: str, value: Any, current: Any) -> Optional[str]:
         return error
 
     direction = _SUGGESTION_DIRECTION.get(key)
-    if direction and isinstance(current, int) and isinstance(value, int):
+    if direction:
+        # Fail closed. A current value that cannot be compared -- absent, None,
+        # a partial dict from a caller -- used to skip the check silently, so
+        # the decrease it exists to refuse went through on the bounds alone.
+        if not isinstance(current, int) or isinstance(current, bool):
+            return f"{key} cannot be checked against its current value ({current!r})"
         if direction == "increase" and value < current:
             return f"{key} may only be increased by a suggestion ({current} -> {value})"
         if direction == "decrease" and value > current:

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -218,6 +218,9 @@ class RunnerConfig:
     community_wait_hours: int = 48
     community_min_comments_for_early: int = 3
     community_improvement_interval_hours: int = 72
+    # Read via getattr in community_improvement and set in the tracked
+    # agent.json, but never declared here, so nothing validated it.
+    community_post_interval_hours: float = 1.0
     # GitHub issue resolution
     enable_github_improvement: bool = False
     github_improvement_interval_hours: int = 12
@@ -328,6 +331,7 @@ def load_runner_config() -> RunnerConfig:
         community_wait_hours=int(data.get("community_wait_hours", 48)),
         community_min_comments_for_early=int(data.get("community_min_comments_for_early", 3)),
         community_improvement_interval_hours=int(data.get("community_improvement_interval_hours", 72)),
+        community_post_interval_hours=float(data.get("community_post_interval_hours", 1.0)),
         enable_github_improvement=bool(data.get("enable_github_improvement", False)),
         github_improvement_interval_hours=int(data.get("github_improvement_interval_hours", 12)),
         enable_issue_scouting=bool(data.get("enable_issue_scouting", False)),

--- a/src/ouroboros/self_modify.py
+++ b/src/ouroboros/self_modify.py
@@ -59,8 +59,11 @@ def filter_untrusted_config_updates(
 
         try:
             current = vars(load_runner_config())
-        except Exception:
-            current = {}
+        except Exception as exc:
+            # Fail closed. Without the current values the direction rule
+            # silently does nothing, so a decrease that should be refused
+            # would be applied.
+            return {}, [f"*: current configuration unreadable ({exc})"]
 
     safe: Dict[str, Any] = {}
     rejected = []

--- a/src/ouroboros/self_modify.py
+++ b/src/ouroboros/self_modify.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 class SelfModificationError(RuntimeError):
@@ -40,73 +40,37 @@ def modify_config(updates: Dict[str, Any], config_type: str = "safety") -> None:
         raise ValueError(f"Unknown config_type: {config_type}")
 
 
-# Config keys that only an operator may set.
-#
-# The comment-upgrade path feeds LLM-extracted key/value pairs from public
-# comments straight into modify_runner_config, and both
-# enable_comment_based_upgrades and auto_apply_config_suggestions default to
-# True. Anything that redirects model traffic, names a credential, or widens
-# the agent's own permissions therefore has to be refused on that path: a
-# suggested reviewer_base_url would send the reviewer credential and the full
-# proposed diff to a host chosen by a commenter, whose reply then decides
-# whether the change is approved.
-OPERATOR_ONLY_CONFIG_KEYS = frozenset({
-    # Endpoint redirection -- exfiltration of credentials and source.
-    "reviewer_base_url",
-    "local_model_base_url",
-    # Credentials.
-    "reviewer_api_key",
-    "ollama_api_key",
-    "telegram_bot_token",
-    "telegram_chat_id",
-    # Model and backend routing -- chooses who sees the code.
-    "reviewer_model",
-    "reviewer_backend",
-    "identify_backend",
-    "plan_backend",
-    "generator_backend",
-    "generator_model",
-    "improvement_model",
-    "issue_scouting_model",
-    "self_improve_model",
-    "local_model",
-    # Permission widening, including over this mechanism itself.
-    "auto_apply_config_suggestions",
-    "dry_run",
-    # Destination and behaviour selectors, as opposed to rate tuning: where the
-    # agent publishes, and whether it publishes at all.
-    "default_submolt",
-    "post_after_self_question",
-})
-
-# Every "enable_*" flag is operator-only. They are the switches that turn on
-# automation which writes outside this process -- pushing branches, opening
-# PRs and issues, posting comments, editing the wiki -- so a commenter must not
-# be able to flip one on. Matching by prefix rather than by name means a flag
-# added later is operator-only on arrival instead of settable from a comment
-# until someone remembers to list it.
-OPERATOR_ONLY_CONFIG_PREFIXES = ("enable_",)
-
-
-def is_operator_only_config_key(key: str) -> bool:
-    """Return True if key may only be set by an operator, not suggested."""
-    return key in OPERATOR_ONLY_CONFIG_KEYS or key.startswith(
-        OPERATOR_ONLY_CONFIG_PREFIXES
-    )
-
-
 def filter_untrusted_config_updates(
-    updates: Dict[str, Any],
-) -> tuple[Dict[str, Any], list]:
-    """Split updates into (applicable, rejected_keys) for an untrusted source.
+    updates: Dict[str, Any], current: Optional[Dict[str, Any]] = None
+) -> "tuple[Dict[str, Any], list]":
+    """Split updates into (applicable, rejected) for a public suggestion.
 
-    Used for config changes suggested by public comments. Operator-driven
-    paths such as the CLI call modify_runner_config directly and are not
-    filtered.
+    An allowlist with bounds, not a deny-list. Under a deny-list every field
+    added to RunnerConfig was suggestible until someone remembered to close
+    it; now a new field is operator-only until someone opens it. See
+    config_schema.COMMENT_SUGGESTIBLE_FIELDS.
+
+    Rejected entries come back as "key: reason" so the loop can log why.
     """
-    safe = {k: v for k, v in updates.items() if not is_operator_only_config_key(k)}
-    rejected = sorted(k for k in updates if is_operator_only_config_key(k))
-    return safe, rejected
+    from . import config_schema
+
+    if current is None:
+        from .moltbook import load_runner_config
+
+        try:
+            current = vars(load_runner_config())
+        except Exception:
+            current = {}
+
+    safe: Dict[str, Any] = {}
+    rejected = []
+    for key, value in updates.items():
+        error = config_schema.validate_suggestion(key, value, current.get(key))
+        if error:
+            rejected.append(f"{key}: {error}")
+        else:
+            safe[key] = value
+    return safe, sorted(rejected)
 
 
 def modify_runner_config(updates: Dict[str, Any]) -> None:

--- a/src/ouroboros/self_modify.py
+++ b/src/ouroboros/self_modify.py
@@ -68,7 +68,9 @@ def filter_untrusted_config_updates(
     safe: Dict[str, Any] = {}
     rejected = []
     for key, value in updates.items():
-        error = config_schema.validate_suggestion(key, value, current.get(key))
+        value, error = config_schema.coerce_suggestion(key, value)
+        if error is None:
+            error = config_schema.validate_suggestion(key, value, current.get(key))
         if error:
             rejected.append(f"{key}: {error}")
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,17 +37,23 @@ def test_cmd_config_show(mock_get, capsys):
 @patch("ouroboros.cli.modify_runner_config")
 def test_cmd_config_modify_success(mock_modify, mock_can, capsys):
     mock_can.return_value = True
-    args = argparse.Namespace(updates=["interval=60", "enable=true", "name=test"])
+    args = argparse.Namespace(updates=[
+        "interval_seconds=60", "enable_auto_merge=true", "reviewer_model=gpt-4o",
+    ])
     ret = cmd_config_modify(args)
     assert ret == 0
-    mock_modify.assert_called_once_with({"interval": 60, "enable": True, "name": "test"})
+    mock_modify.assert_called_once_with({
+        "interval_seconds": 60,
+        "enable_auto_merge": True,
+        "reviewer_model": "gpt-4o",
+    })
     captured = capsys.readouterr()
     assert "Updated runner config" in captured.out
 
 @patch("ouroboros.cli.can_self_modify")
 def test_cmd_config_modify_disabled(mock_can, capsys):
     mock_can.return_value = False
-    args = argparse.Namespace(updates=["k=v"])
+    args = argparse.Namespace(updates=["interval_seconds=30"])
     ret = cmd_config_modify(args)
     assert ret == 2
     captured = capsys.readouterr()
@@ -264,22 +270,25 @@ def test_cmd_config_modify_rejects_before_applying_earlier_valid_pairs(
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
-        ("k=true", True),
-        ("k=True", True),
-        ("k=false", False),
-        ("k=FALSE", False),
-        ("k=42", 42),
-        ("k=-42", -42),
-        ("k=1.5", "1.5"),   # not an int field, so left alone
-        ("k=text", "text"),
-        ("k=a=b", "a=b"),  # only the first separator splits
+        ("enable_auto_merge=true", {"enable_auto_merge": True}),
+        ("enable_auto_merge=True", {"enable_auto_merge": True}),
+        ("enable_auto_merge=false", {"enable_auto_merge": False}),
+        ("enable_auto_merge=off", {"enable_auto_merge": False}),
+        ("interval_seconds=42", {"interval_seconds": 42}),
+        ("reviewer_model=gpt-4o", {"reviewer_model": "gpt-4o"}),
+        # Only the first separator splits.
+        ("reviewer_base_url=https://x/v1?a=b",
+         {"reviewer_base_url": "https://x/v1?a=b"}),
+        ("improvement_types=fix_bug, add_test",
+         {"improvement_types": ["fix_bug", "add_test"]}),
     ],
 )
 @patch("ouroboros.cli.can_self_modify", return_value=True)
 @patch("ouroboros.cli.modify_runner_config")
 def test_cmd_config_modify_value_parsing(mock_modify, _can, raw, expected):
+    """The type comes from the field, not from guessing at the text."""
     assert cmd_config_modify(argparse.Namespace(updates=[raw])) == 0
-    assert mock_modify.call_args.args[0] == {"k": expected}
+    assert mock_modify.call_args.args[0] == expected
 
 
 @pytest.mark.parametrize(
@@ -351,24 +360,24 @@ def test_cmd_config_modify_accepts_a_valid_interval(mock_modify, _can):
     assert mock_modify.call_args.args[0] == {"interval_seconds": 60}
 
 
-def test_int_config_fields_are_read_from_the_dataclass():
+def test_the_schema_is_derived_from_the_dataclass():
     """Hardcoding the list would leave a new field unvalidated."""
-    from ouroboros.cli import _int_config_fields
+    from ouroboros import config_schema
 
-    fields = _int_config_fields()
-    assert "interval_seconds" in fields
-    assert "improvement_interval_hours" in fields
-    assert "reviewer_model" not in fields
-    assert "enable_auto_merge" not in fields
+    types = config_schema.field_types()
+    assert "interval_seconds" in types
+    assert "improvement_interval_hours" in types
+    assert "reviewer_model" in types
+    assert "enable_auto_merge" in types
 
 
-def test_a_valid_interval_survives_the_round_trip_to_the_loader(tmp_path):
+def test_a_valid_interval_survives_the_round_trip_to_the_loader():
     """The real check: what the CLI writes must be what the loader can read."""
-    from ouroboros.cli import _parse_config_value
+    from ouroboros.config_schema import parse_value
     from ouroboros.moltbook import RunnerConfig
 
-    written = _parse_config_value("60")
-    assert int(written) == 60
+    written, error = parse_value("interval_seconds", "60")
+    assert error is None
     assert RunnerConfig(interval_seconds=int(written)).interval_seconds == 60
 
 
@@ -400,3 +409,129 @@ def test_cmd_backlog_organize_reports_success(mock_org, _root, _key, _client, ca
 
     assert cmd_backlog_clean(argparse.Namespace()) == 0
     assert "3 kept" in capsys.readouterr().out
+
+
+# -- config_schema -----------------------------------------------------------
+
+def test_unknown_key_suggests_a_near_match():
+    from ouroboros.config_schema import validate
+
+    error = validate("interval_secnds", 60)
+    assert "unknown setting" in error
+    assert "interval_seconds" in error, "a silently ignored typo is the worst outcome"
+
+
+def test_a_typo_is_rejected_rather_than_silently_stored():
+    from ouroboros.config_schema import validate
+
+    assert validate("enabel_auto_merge", True) is not None
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("interval_seconds", 1800),
+        ("max_comments_per_cycle", 0),
+        ("oddities_digest_hour", 0),
+        ("oddities_digest_hour", 23),
+        ("enable_auto_merge", True),
+        ("reviewer_model", "gpt-4o"),
+        ("reviewer_base_url", ""),
+        ("improvement_types", ["fix_bug"]),
+    ],
+)
+def test_valid_settings_pass(key, value):
+    from ouroboros.config_schema import validate
+
+    assert validate(key, value) is None
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "why"),
+    [
+        ("interval_seconds", 0, "busy loop"),
+        ("interval_seconds", -1, "negative sleep"),
+        ("interval_seconds", 10**12, "parks the agent for millennia"),
+        ("oddities_digest_hour", 24, "not an hour of the day"),
+        ("oddities_digest_hour", -1, "not an hour of the day"),
+        ("max_comments_per_cycle", -1, "negative count"),
+        ("interval_seconds", True, "bool is an int subclass"),
+        ("interval_seconds", "1800", "a string for a numeric field"),
+        ("enable_auto_merge", 1, "an int for a boolean field"),
+        ("enable_auto_merge", "yes", "a string for a boolean field"),
+    ],
+)
+def test_invalid_settings_are_rejected(key, value, why):
+    from ouroboros.config_schema import validate
+
+    assert validate(key, value) is not None, why
+
+
+def test_every_int_field_has_a_positive_floor():
+    """A missing bounds entry must not mean "anything goes"."""
+    from dataclasses import fields
+
+    from ouroboros.config_schema import validate
+    from ouroboros.moltbook import RunnerConfig
+
+    for field in fields(RunnerConfig):
+        if field.type in ("int", int):
+            assert validate(field.name, -1) is not None, field.name
+
+
+def test_every_default_is_itself_valid():
+    """The shipped defaults must satisfy the schema that guards them."""
+    from dataclasses import fields
+
+    from ouroboros.config_schema import validate
+    from ouroboros.moltbook import RunnerConfig
+
+    cfg = RunnerConfig()
+    for field in fields(RunnerConfig):
+        value = getattr(cfg, field.name)
+        assert validate(field.name, value) is None, f"{field.name}={value!r}"
+
+
+@pytest.mark.parametrize(
+    ("key", "raw", "expected"),
+    [
+        ("interval_seconds", "60", 60),
+        ("enable_auto_merge", "true", True),
+        ("enable_auto_merge", "off", False),
+        ("reviewer_model", "gpt-4o", "gpt-4o"),
+        ("reviewer_base_url", "", ""),
+        ("improvement_types", "fix_bug, add_test", ["fix_bug", "add_test"]),
+        ("improvement_types", "", None),
+    ],
+)
+def test_parse_value_uses_the_declared_type(key, raw, expected):
+    from ouroboros.config_schema import parse_value
+
+    parsed, error = parse_value(key, raw)
+    assert error is None
+    assert parsed == expected
+
+
+@pytest.mark.parametrize(
+    ("key", "raw"),
+    [
+        ("interval_seconds", "1.5"),
+        ("interval_seconds", "abc"),
+        ("interval_seconds", ""),
+        ("enable_auto_merge", "maybe"),
+        ("nonexistent_field", "1"),
+    ],
+)
+def test_parse_value_reports_bad_input(key, raw):
+    from ouroboros.config_schema import parse_value
+
+    _parsed, error = parse_value(key, raw)
+    assert error is not None
+
+
+def test_credential_aliases_are_settable():
+    """ollama_api_key is not a RunnerConfig field, but config modify routes it
+    to credentials.json, so the schema has to know it."""
+    from ouroboros.config_schema import validate
+
+    assert validate("ollama_api_key", "secret") is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -535,3 +535,46 @@ def test_credential_aliases_are_settable():
     from ouroboros.config_schema import validate
 
     assert validate("ollama_api_key", "secret") is None
+
+
+def test_every_tracked_config_key_is_a_known_setting():
+    """The checked-in config is the operator's worked example.
+
+    A key that lives there but is not a RunnerConfig field is either dead or
+    read behind a getattr default -- and the schema would reject an operator
+    setting the project itself ships.
+    """
+    import json
+    from pathlib import Path
+
+    from ouroboros.config_schema import field_types, validate
+
+    tracked = Path(__file__).resolve().parents[1] / "config" / "agent.json"
+    if not tracked.exists():
+        pytest.skip("no tracked sample config")
+
+    known = field_types()
+    for key, value in json.loads(tracked.read_text()).items():
+        assert key in known, f"{key} is in config/agent.json but not a setting"
+        assert validate(key, value) is None, f"{key}={value!r}"
+
+
+def test_setting_a_superseded_key_is_refused_rather_than_silently_ignored():
+    """The loader honours self_improve_interval_hours only when
+    improvement_interval_hours is absent, so writing it normally reports
+    success and changes nothing."""
+    from ouroboros.config_schema import settable_error
+
+    error = settable_error("self_improve_interval_hours")
+    assert error and "improvement_interval_hours" in error
+    assert settable_error("improvement_interval_hours") is None
+
+
+def test_a_float_field_parses_and_validates_as_a_float():
+    from ouroboros.config_schema import parse_value, validate
+
+    value, error = parse_value("community_post_interval_hours", "0.5")
+    assert (value, error) == (0.5, None)
+    assert validate("community_post_interval_hours", 0.5) is None
+    assert validate("community_post_interval_hours", 0) is not None
+    assert validate("community_post_interval_hours", "soon") is not None

--- a/tests/test_self_modify.py
+++ b/tests/test_self_modify.py
@@ -273,3 +273,109 @@ def test_a_deprecated_alias_is_not_suggestible():
         {"self_improve_interval_hours": 96}, {"self_improve_interval_hours": 48}
     )
     assert safe == {}
+
+
+# -- the allowlist cannot drift away from its guards -------------------------
+
+def test_every_suggestible_field_has_a_direction_and_bounds():
+    """Opening a field for suggestion without a direction entry gives it no
+    direction check at all -- silently, which is how the deny-list this
+    replaced went wrong."""
+    from ouroboros.config_schema import (
+        COMMENT_SUGGESTIBLE_FIELDS,
+        _SUGGESTION_BOUNDS,
+        _SUGGESTION_DIRECTION,
+        field_types,
+    )
+
+    known = field_types()
+    for name in COMMENT_SUGGESTIBLE_FIELDS:
+        assert name in known, f"{name} is suggestible but not a setting"
+        assert name in _SUGGESTION_DIRECTION, f"{name} has no declared direction"
+        assert name in _SUGGESTION_BOUNDS, f"{name} has no suggestion bounds"
+
+
+def test_suggestion_guards_do_not_name_fields_that_are_not_suggestible():
+    from ouroboros.config_schema import (
+        COMMENT_SUGGESTIBLE_FIELDS,
+        _SUGGESTION_BOUNDS,
+        _SUGGESTION_DIRECTION,
+    )
+
+    assert set(_SUGGESTION_DIRECTION) == set(COMMENT_SUGGESTIBLE_FIELDS)
+    assert set(_SUGGESTION_BOUNDS) == set(COMMENT_SUGGESTIBLE_FIELDS)
+
+
+# -- an uncomparable current value must fail, not skip the check -------------
+
+def test_a_missing_current_value_refuses_the_suggestion():
+    """isinstance(None, int) is False, so the direction rule used to skip
+    rather than fail -- and interval_seconds=60 passed on bounds alone."""
+    safe, reason = _reject_reason({"interval_seconds": 60}, {})
+    assert safe == {}
+    assert "cannot be checked" in reason
+
+
+def test_a_partial_current_config_does_not_open_the_other_fields():
+    safe, _ = filter_untrusted_config_updates(
+        {"interval_seconds": 60, "max_comments_per_cycle": 1},
+        {"max_comments_per_cycle": 3},
+    )
+    assert "interval_seconds" not in safe
+    assert safe == {"max_comments_per_cycle": 1}
+
+
+# -- model-shaped values are coerced, not waved through ----------------------
+
+def test_a_string_number_from_a_model_is_coerced_and_still_guarded():
+    """The old deny-list passed "60" straight to the loader, which coerced it.
+    Coercing here keeps that working *and* makes it comparable -- a str is
+    uncomparable, so it would otherwise dodge the direction rule."""
+    safe, _ = filter_untrusted_config_updates(
+        {"interval_seconds": "3600"}, {"interval_seconds": 1800}
+    )
+    assert safe == {"interval_seconds": 3600}
+
+    blocked, reason = _reject_reason(
+        {"interval_seconds": "60"}, {"interval_seconds": 1800}
+    )
+    assert blocked == {}
+    assert "only be increased" in reason
+
+
+def test_a_whole_float_from_a_model_is_coerced_and_still_guarded():
+    safe, _ = filter_untrusted_config_updates(
+        {"interval_seconds": 3600.0}, {"interval_seconds": 1800}
+    )
+    assert safe == {"interval_seconds": 3600}
+
+    blocked, _ = filter_untrusted_config_updates(
+        {"interval_seconds": 60.0}, {"interval_seconds": 1800}
+    )
+    assert blocked == {}
+
+
+def test_a_fractional_value_is_still_refused_for_a_whole_number_field():
+    safe, _ = filter_untrusted_config_updates(
+        {"interval_seconds": 3600.5}, {"interval_seconds": 1800}
+    )
+    assert safe == {}
+
+
+# -- throttling may not become silencing -------------------------------------
+
+def test_a_suggestion_may_not_silence_commenting_outright():
+    """0 is a legitimate operator setting meaning "do not comment"; a stranger
+    reaching it is not a throttle."""
+    safe, _ = filter_untrusted_config_updates(
+        {"max_comments_per_cycle": 0}, {"max_comments_per_cycle": 3}
+    )
+    assert safe == {}
+
+
+def test_a_suggestion_may_not_park_the_channel_it_arrived_through():
+    """Comments are how a bad suggestion gets undone."""
+    safe, _ = filter_untrusted_config_updates(
+        {"comment_check_interval_hours": 168}, {"comment_check_interval_hours": 6}
+    )
+    assert safe == {}

--- a/tests/test_self_modify.py
+++ b/tests/test_self_modify.py
@@ -70,149 +70,129 @@ def test_can_self_modify(mock_safety):
     mock_instance.allow_self_modification = False
     assert can_self_modify() is False
 
-
 # -- untrusted (comment-suggested) config updates ----------------------------
+
+def _reject_reason(updates, current=None):
+    safe, rejected = filter_untrusted_config_updates(updates, current or {})
+    return safe, " ".join(rejected)
+
 
 @pytest.mark.parametrize(
     "key",
     [
+        # Endpoint redirection and credentials.
         "reviewer_base_url",
         "local_model_base_url",
         "reviewer_api_key",
-        "ollama_api_key",
         "telegram_bot_token",
+        # Model and backend routing -- chooses who sees the code.
         "reviewer_model",
-        "reviewer_backend",
         "generator_backend",
         "improvement_model",
-        "auto_apply_config_suggestions",
-        "enable_comment_based_upgrades",
-        "enable_self_modification",
+        # Capability switches.
+        "enable_self_improvement",
+        "enable_auto_git_push",
         "enable_auto_merge",
+        "enable_comment_based_upgrades",
+        "auto_apply_config_suggestions",
         "dry_run",
+        # Destination and behaviour selectors.
+        "default_submolt",
+        "post_after_self_question",
     ],
 )
-def test_filter_untrusted_config_updates_rejects_operator_only_keys(key):
-    safe, rejected = filter_untrusted_config_updates({key: "x"})
+def test_operator_only_fields_are_refused(key):
+    safe, reason = _reject_reason({key: "x"})
     assert safe == {}
-    assert rejected == [key]
+    assert "operator" in reason
 
 
-def test_filter_untrusted_config_updates_allows_ordinary_keys():
-    updates = {"min_post_interval_hours": 24, "max_comments_per_cycle": 5}
-    safe, rejected = filter_untrusted_config_updates(updates)
-    assert safe == updates
+def test_an_unknown_field_is_refused():
+    """A deny-list would have accepted anything it had not heard of."""
+    safe, reason = _reject_reason({"some_field_added_next_year": 1})
+    assert safe == {}
+    assert "operator" in reason
+
+
+def test_every_field_outside_the_allowlist_is_refused():
+    """The allowlist is the whole surface, checked against the real dataclass."""
+    from dataclasses import fields
+
+    from ouroboros.config_schema import COMMENT_SUGGESTIBLE_FIELDS
+    from ouroboros.moltbook import RunnerConfig
+
+    everything = {f.name: 1 for f in fields(RunnerConfig)}
+    safe, _ = filter_untrusted_config_updates(everything, {})
+
+    assert set(safe) <= COMMENT_SUGGESTIBLE_FIELDS
+
+
+def test_a_tuning_field_is_accepted():
+    safe, rejected = filter_untrusted_config_updates(
+        {"min_post_interval_hours": 24}, {"min_post_interval_hours": 12}
+    )
+    assert safe == {"min_post_interval_hours": 24}
     assert rejected == []
 
 
-def test_filter_untrusted_config_updates_splits_mixed_input():
-    """The exfiltration key is dropped; the benign one still applies."""
-    safe, rejected = filter_untrusted_config_updates({
-        "min_post_interval_hours": 24,
-        "reviewer_base_url": "https://attacker.example/v1",
-    })
+def test_a_mixed_suggestion_keeps_only_the_allowed_part():
+    safe, rejected = filter_untrusted_config_updates(
+        {"min_post_interval_hours": 24, "reviewer_base_url": "https://attacker/v1"},
+        {"min_post_interval_hours": 12},
+    )
     assert safe == {"min_post_interval_hours": 24}
-    assert rejected == ["reviewer_base_url"]
+    assert len(rejected) == 1
 
 
-def test_ollama_api_key_is_canonicalised_to_reviewer_api_key(tmp_path):
-    """Rotating via the alias must not leave the old key in effect."""
-    cfg_file = tmp_path / "agent.json"
-    cred_file = tmp_path / "credentials.json"
-    cred_file.write_text(json.dumps({"reviewer_api_key": "old"}))
+# -- suggestions may only reduce activity ------------------------------------
 
-    def fake_expanduser(path):
-        if path.endswith("agent.json"):
-            return str(cfg_file)
-        if path.endswith("credentials.json"):
-            return str(cred_file)
-        return path
-
-    with mock.patch("ouroboros.self_modify.os.path.expanduser", side_effect=fake_expanduser):
-        modify_runner_config({"ollama_api_key": "new"})
-
-    creds = json.loads(cred_file.read_text())
-    assert creds["reviewer_api_key"] == "new"
-    assert "ollama_api_key" not in creds
-    assert json.loads(cfg_file.read_text()).get("ollama_api_key") is None
+def test_an_interval_may_be_increased_by_a_suggestion():
+    safe, _ = filter_untrusted_config_updates(
+        {"interval_seconds": 3600}, {"interval_seconds": 1800}
+    )
+    assert safe == {"interval_seconds": 3600}
 
 
-def test_every_enable_flag_is_operator_only():
-    """No comment may switch on automation that writes outside this process."""
-    from dataclasses import fields
-
-    from ouroboros.moltbook import RunnerConfig
-
-    enable_flags = [f.name for f in fields(RunnerConfig) if f.name.startswith("enable_")]
-    assert enable_flags, "expected RunnerConfig to have enable_* flags"
-
-    safe, rejected = filter_untrusted_config_updates({f: True for f in enable_flags})
+def test_an_interval_may_not_be_decreased_by_a_suggestion():
+    """"Poll ten times faster" is exactly what a stranger must not be able to
+    ask for; the bounds alone would have allowed it."""
+    safe, reason = _reject_reason(
+        {"interval_seconds": 60}, {"interval_seconds": 1800}
+    )
     assert safe == {}
-    assert rejected == sorted(enable_flags)
+    assert "only be increased" in reason
 
+
+def test_a_count_may_be_reduced_by_a_suggestion():
+    safe, _ = filter_untrusted_config_updates(
+        {"max_comments_per_cycle": 1}, {"max_comments_per_cycle": 3}
+    )
+    assert safe == {"max_comments_per_cycle": 1}
+
+
+def test_a_count_may_not_be_raised_by_a_suggestion():
+    safe, reason = _reject_reason(
+        {"max_comments_per_cycle": 50}, {"max_comments_per_cycle": 3}
+    )
+    assert safe == {}
+    assert "only be reduced" in reason
+
+
+# -- bounds ------------------------------------------------------------------
 
 @pytest.mark.parametrize(
-    "key",
+    ("key", "value"),
     [
-        "enable_self_improvement",
-        "enable_github_improvement",
-        "enable_auto_git_push",
-        "enable_issue_scouting",
-        "enable_community_improvement",
-        "enable_auto_comment",
-        "enable_wiki",
-        "enable_self_modification",
-        "enable_comment_based_upgrades",
-        "enable_auto_merge",
+        ("interval_seconds", 0),           # busy loop
+        ("interval_seconds", -1),
+        ("interval_seconds", 10**12),      # parks the agent for millennia
+        ("max_comments_per_cycle", -1),
+        ("max_comments_per_cycle", 10_000),
+        ("interval_seconds", "not a number"),
+        ("interval_seconds", 1.5),
+        ("interval_seconds", True),        # bool is an int subclass
     ],
 )
-def test_repository_mutating_flags_are_rejected(key):
-    safe, rejected = filter_untrusted_config_updates({key: True})
+def test_out_of_range_and_wrong_typed_suggestions_are_refused(key, value):
+    safe, _ = filter_untrusted_config_updates({key: value}, {key: 1800})
     assert safe == {}
-    assert rejected == [key]
-
-
-def test_operator_path_can_still_set_everything(tmp_path):
-    """The denylist applies to suggestions only, not to the operator."""
-    cfg_file = tmp_path / "agent.json"
-    cred_file = tmp_path / "credentials.json"
-
-    def fake_expanduser(path):
-        if path.endswith("agent.json"):
-            return str(cfg_file)
-        if path.endswith("credentials.json"):
-            return str(cred_file)
-        return path
-
-    with mock.patch("ouroboros.self_modify.os.path.expanduser", side_effect=fake_expanduser):
-        modify_runner_config({
-            "enable_self_improvement": True,
-            "reviewer_base_url": "https://ollama.com/v1",
-        })
-
-    data = json.loads(cfg_file.read_text())
-    assert data["enable_self_improvement"] is True
-    assert data["reviewer_base_url"] == "https://ollama.com/v1"
-
-
-def test_no_model_or_backend_key_is_suggestible():
-    """Anything naming a model or backend decides who sees the source."""
-    from dataclasses import fields
-
-    from ouroboros.moltbook import RunnerConfig
-
-    routing = [
-        f.name
-        for f in fields(RunnerConfig)
-        if f.name.endswith(("_model", "_backend", "_base_url", "_api_key"))
-    ]
-    safe, _ = filter_untrusted_config_updates({f: "x" for f in routing})
-    assert safe == {}
-
-
-@pytest.mark.parametrize("key", ["default_submolt", "post_after_self_question"])
-def test_destination_and_behaviour_selectors_are_operator_only(key):
-    """Where the agent publishes, and whether it does, is not a suggestion."""
-    safe, rejected = filter_untrusted_config_updates({key: "attacker-submolt"})
-    assert safe == {}
-    assert rejected == [key]

--- a/tests/test_self_modify.py
+++ b/tests/test_self_modify.py
@@ -196,3 +196,80 @@ def test_a_count_may_not_be_raised_by_a_suggestion():
 def test_out_of_range_and_wrong_typed_suggestions_are_refused(key, value):
     safe, _ = filter_untrusted_config_updates({key: value}, {key: 1800})
     assert safe == {}
+
+
+# -- a suggestion may not park the agent -------------------------------------
+
+def test_an_interval_may_not_be_raised_past_the_public_ceiling():
+    """The direction rule alone makes "less active" unbounded.
+
+    interval_seconds has an operator ceiling of a year, and a year is an
+    increase, so the direction rule waves it through -- a comment could stop
+    the agent for as long as it liked while every guard reported success.
+    """
+    safe, reason = _reject_reason(
+        {"interval_seconds": 31_536_000}, {"interval_seconds": 1800}
+    )
+    assert safe == {}
+    assert "may not be set above 21600" in reason
+
+
+def test_error_throttling_may_not_be_raised_to_a_year_by_a_suggestion():
+    """Silencing the alerts is how you hide having parked the agent."""
+    safe, _ = filter_untrusted_config_updates(
+        {"telegram_error_min_interval_seconds": 31_536_000},
+        {"telegram_error_min_interval_seconds": 300},
+    )
+    assert safe == {}
+
+
+def test_a_suggestion_may_still_throttle_within_the_ceiling():
+    safe, _ = filter_untrusted_config_updates(
+        {"interval_seconds": 7200}, {"interval_seconds": 1800}
+    )
+    assert safe == {"interval_seconds": 7200}
+
+
+# -- direction is declared, not guessed from the name ------------------------
+
+def test_lowering_the_early_analysis_threshold_is_refused():
+    """It reads like a capacity count, so a name-suffix heuristic classified it
+    as reduce-only -- but lowering it makes the agent analyse *sooner*."""
+    safe, reason = _reject_reason(
+        {"community_min_comments_for_early": 0},
+        {"community_min_comments_for_early": 5},
+    )
+    assert safe == {}
+    assert "only be increased" in reason
+
+
+def test_raising_the_early_analysis_threshold_is_allowed():
+    safe, _ = filter_untrusted_config_updates(
+        {"community_min_comments_for_early": 10},
+        {"community_min_comments_for_early": 5},
+    )
+    assert safe == {"community_min_comments_for_early": 10}
+
+
+# -- fail closed -------------------------------------------------------------
+
+def test_an_unreadable_current_config_rejects_every_suggestion(monkeypatch):
+    """Without the current values the direction rule silently passes everything,
+    so a decrease that should be refused would be applied."""
+    import ouroboros.moltbook as moltbook
+
+    def boom():
+        raise OSError("config unreadable")
+
+    monkeypatch.setattr(moltbook, "load_runner_config", boom)
+
+    safe, rejected = filter_untrusted_config_updates({"interval_seconds": 60})
+    assert safe == {}
+    assert any("unreadable" in r for r in rejected)
+
+
+def test_a_deprecated_alias_is_not_suggestible():
+    safe, _ = filter_untrusted_config_updates(
+        {"self_improve_interval_hours": 96}, {"self_improve_interval_hours": 48}
+    )
+    assert safe == {}


### PR DESCRIPTION
Closes #63. Closes #54.

Two callers decided independently what a `RunnerConfig` field may hold, and they had diverged. The operator CLI accepted any key and almost any value — `config modify interval_seconds=1.5` was stored happily and bricked startup, and a typo'd key reported success and did nothing. The comment-upgrade path decided what a stranger may change with a **deny-list**, so every field added since it was written was suggestible until someone remembered to close it.

`config_schema.py` is now the single source of truth. Field names and types come from the dataclass; only bounds are written down, and only where a value is nonsensical rather than merely unusual. The public path is an **allowlist** — a new field is operator-only until someone deliberately opens it.

## What review found on top of that

The first draft's guard rule was "a suggestion may only make the agent less active." Both reviewers independently broke it:

- **A year is an increase.** `interval_seconds=31536000` passed the direction rule and parked the runner, and the same move on `telegram_error_min_interval_seconds` would have hidden that it had. Suggestions now get their own ceilings, far tighter than the operator ones.
- **The direction was inferred from the field name.** `community_min_comments_for_early` reads like a capacity count, but lowering it makes the agent analyse *sooner* — so the heuristic had it exactly backwards. Directions are now declared per field, and all ten were checked against what the code does with them rather than what they are called.
- **The rule skipped what it could not compare.** A current value that was absent, `None`, or a string/float from the model made `isinstance(current, int)` false, so the check was skipped rather than failed — `interval_seconds=60` then went through on bounds alone. It now fails closed, and model-shaped values are coerced first so there is something to compare.
- **Throttling could reach silence.** `max_comments_per_cycle` floors at 1 for a suggestion — 0 is a legitimate operator setting meaning "do not comment", but a stranger reaching it is not a throttle — and `comment_check_interval_hours` caps at a day, since comments are the channel a bad suggestion gets undone through.
- **Two loader/schema drifts.** `community_post_interval_hours` is set in the tracked `config/agent.json` and read via `getattr`, but was never a dataclass field, so the new schema rejected a setting the project itself ships. `self_improve_interval_hours` is ignored whenever `improvement_interval_hours` is present, so setting it reported success and changed nothing.

## Invariants

Three tests now hold the structure rather than the symptoms: every shipped default validates, every key in the tracked config is a real setting, and every suggestible field has both a declared direction and suggestion bounds. That last one is the deny-list failure mode in reverse — a field opened without a direction entry would get no direction check at all, silently.

An AST scan for undeclared `RunnerConfig` fields read via `getattr` found no remaining drift.

## Rejected

The claim that `ollama_api_key` now writes a plaintext secret to `agent.json`. The removed line was from the deleted deny-list, not the credential routing, which still canonicalises it to `reviewer_api_key` in `credentials.json` — confirmed by running `modify_runner_config` against a temp dir.

853 tests pass (was 834).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EctMqruGhEtygspBS172cG