### PR TITLE
fix(feed): separate feed visibility from knowledge processing (#67)

### DIFF
--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -593,6 +593,11 @@ def _drain_extraction_queue(
         return [], []
 
     batch = pending[:limit]
+    for entry in batch:
+        # _record_knowledge saves state on a write failure, and save_state
+        # trims -- with the batch still queued, since release comes after
+        # recording. Nothing in flight may be evicted underneath us.
+        entry["in_flight"] = True
     try:
         insights = llm.extract_insights_batch(client, batch)
     except Exception:
@@ -608,6 +613,8 @@ def _drain_extraction_queue(
         # did not parse, and either way we cannot say these posts were read.
         for entry in batch:
             entry["attempts"] = int(entry.get("attempts", 0) or 0) + 1
+        for entry in batch:
+            entry.pop("in_flight", None)
         spent = [e for e in batch if e["attempts"] >= MAX_EXTRACTION_ATTEMPTS]
         if spent:
             ids = {e.get("id") for e in spent}
@@ -664,9 +671,12 @@ def _release_extracted(state: Dict[str, Any], post_ids: List[Any]) -> None:
     them inside the drain instead left a window where an exception between
     extracting and recording lost both.
     """
-    if not post_ids:
+    # A None in here would match every entry whose id is missing and purge
+    # them all. _queue_for_extraction never admits one, but the invariant
+    # belongs where the deletion happens.
+    done = {pid for pid in post_ids if pid is not None}
+    if not done:
         return
-    done = set(post_ids)
     state["knowledge_pending"] = [
         entry for entry in state.get("knowledge_pending", [])
         if entry.get("id") not in done
@@ -751,17 +761,24 @@ def _trim_state(state: Dict[str, Any]) -> None:
 
     queued = state.get("knowledge_pending", [])
     if len(queued) > MAX_KNOWLEDGE_PENDING:
-        # Named, not silent: a dropped post is one the agent will never learn
-        # from, which is the bug this queue exists to fix. The newest are kept
-        # -- reaching the cap means being a long way behind, and by then a
-        # fresh post is worth more than one from twenty hours ago.
-        dropped = queued[:-MAX_KNOWLEDGE_PENDING]
-        state["knowledge_pending"] = queued[-MAX_KNOWLEDGE_PENDING:]
-        log.warning(
-            "[knowledge-base] Queue over %d; dropped %d oldest: %s",
-            MAX_KNOWLEDGE_PENDING, len(dropped),
-            ", ".join(str(e.get("id")) for e in dropped),
-        )
+        # A batch mid-extraction is never a candidate: it is about to be
+        # released, and evicting it would lose an insight already paid for.
+        in_flight = [e for e in queued if e.get("in_flight")]
+        rest = [e for e in queued if not e.get("in_flight")]
+        room = max(0, MAX_KNOWLEDGE_PENDING - len(in_flight))
+        dropped = rest[:-room] if room else rest
+        if dropped:
+            # Named, not silent: a dropped post is one the agent never learns
+            # from, which is the bug this queue exists to fix. The oldest go
+            # first -- the drain already took the head this cycle, and by the
+            # time the cap bites, a fresh post is worth more than one from
+            # twenty hours ago.
+            log.warning(
+                "[knowledge-base] Queue over %d; dropped %d oldest: %s",
+                MAX_KNOWLEDGE_PENDING, len(dropped),
+                ", ".join(str(e.get("id")) for e in dropped),
+            )
+        state["knowledge_pending"] = in_flight + (rest[-room:] if room else [])
 
     _trim_comment_history(state, limit=MAX_COMMENT_HISTORY)
     _trim_self_question_log(state)
@@ -1311,6 +1328,18 @@ def run_loop() -> int:
                         # Only now: _record_knowledge has either written the
                         # entries or queued them in the outbox.
                         _release_extracted(state, processed_ids)
+                        if processed_ids:
+                            # Checkpoint rather than waiting for the end of the
+                            # cycle: a crash in between would re-extract a
+                            # batch already recorded, paying for the LLM call
+                            # twice and duplicating the entries.
+                            try:
+                                save_state(state)
+                            except Exception:
+                                log.warning(
+                                    "Could not checkpoint the extraction queue",
+                                    exc_info=True,
+                                )
                     except Exception:
                         log.exception("Knowledge base population failed")
 

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -38,6 +38,12 @@ _COMMENTS_IN_SQLITE = "_comments_in_sqlite"
 _COMMENT_MIGRATION = "comment_history_v1"
 MAX_SELF_UPGRADES = 50
 MAX_COMMUNITY_HISTORY = 20
+MAX_KNOWLEDGE_PENDING = 200
+KNOWLEDGE_BATCH_SIZE = 5
+# A batch that always fails sits at the head of the queue forever, and nothing
+# behind it is ever extracted. Bound the retries rather than the queue.
+MAX_EXTRACTION_ATTEMPTS = 3
+MAX_PENDING_CONTENT_CHARS = 2000
 
 
 def _handle_shutdown(signum: int, _frame: Any) -> None:
@@ -365,6 +371,7 @@ def _default_state() -> Dict[str, Any]:
         "self_question_log": [],
         "comment_history": [],
         "seen_post_ids": [],
+        "knowledge_pending": [],
         "community_improvement": None,
         "community_improvement_history": [],
         "last_community_improvement_start": None,
@@ -535,11 +542,124 @@ def record_comment(state: Dict[str, Any], entry: Dict[str, Any]) -> None:
     state.setdefault("comment_history", []).append(entry)
 
 
+def _queue_for_extraction(state: Dict[str, Any], posts: List[Dict[str, Any]]) -> int:
+    """Queue posts for knowledge extraction. Returns how many were added.
+
+    seen_post_ids answers "already displayed"; this answers "already
+    considered for an insight". One list did both, so the per-cycle LLM budget
+    silently doubled as a cap on how many posts were ever looked at: with ten
+    posts a fetch, the sixth uncommented one was checkpointed as seen without
+    reaching extraction, and later cycles filter on seen, so it never came
+    back.
+    """
+    pending = state.setdefault("knowledge_pending", [])
+    known = {entry.get("id") for entry in pending}
+    added = 0
+    for post in posts:
+        pid = post.get("id")
+        if not pid or pid in known:
+            continue
+        known.add(pid)
+        pending.append({
+            "id": pid,
+            "title": post.get("title", ""),
+            "content": (post.get("content") or "")[:MAX_PENDING_CONTENT_CHARS],
+            "attempts": 0,
+        })
+        added += 1
+
+    excess = len(pending) - MAX_KNOWLEDGE_PENDING
+    if excess > 0:
+        dropped = pending[:excess]
+        del pending[:excess]
+        # Named, not silent: a dropped post is one the agent will never learn
+        # from, and that is the bug this queue exists to fix.
+        log.warning(
+            "[knowledge-base] Queue over %d; dropped %d oldest: %s",
+            MAX_KNOWLEDGE_PENDING, len(dropped),
+            ", ".join(str(e.get("id")) for e in dropped),
+        )
+    return added
+
+
+def _drain_extraction_queue(
+    state: Dict[str, Any], client: Any, limit: int = KNOWLEDGE_BATCH_SIZE
+) -> List[Dict[str, Any]]:
+    """Extract insights for the head of the queue and return the entries.
+
+    A post leaves the queue once it has a decision: an insight, or a batch
+    that ran and found none. extract_insights_batch returns None only when the
+    call failed, so a transient failure leaves the posts queued rather than
+    dropping them.
+    """
+    from . import llm  # local, matching the rest of this module
+
+    pending = state.get("knowledge_pending") or []
+    if not pending:
+        return []
+
+    batch = pending[:limit]
+    insights = llm.extract_insights_batch(client, batch)
+
+    if not isinstance(insights, list):
+        # None is the failure sentinel; anything else non-list means the reply
+        # did not parse, and either way we cannot say these posts were read.
+        for entry in batch:
+            entry["attempts"] = int(entry.get("attempts", 0) or 0) + 1
+        spent = [e for e in batch if e["attempts"] >= MAX_EXTRACTION_ATTEMPTS]
+        if spent:
+            ids = {e.get("id") for e in spent}
+            state["knowledge_pending"] = [
+                e for e in pending if e.get("id") not in ids
+            ]
+            log.warning(
+                "[knowledge-base] Giving up on %d post(s) after %d attempts: %s",
+                len(spent), MAX_EXTRACTION_ATTEMPTS,
+                ", ".join(str(e.get("id")) for e in spent),
+            )
+        else:
+            log.info(
+                "[knowledge-base] Extraction failed; %d post(s) stay queued",
+                len(batch),
+            )
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    now = int(time.time())
+    for item in insights:
+        if not isinstance(item, dict):
+            continue
+        try:
+            idx = int(item.get("post_index", -1))
+        except (TypeError, ValueError):
+            continue
+        if not 0 <= idx < len(batch):
+            continue
+        insight = item.get("insight") or ""
+        if not insight:
+            continue
+        entries.append({
+            "post_id": batch[idx].get("id"),
+            "post_title": batch[idx].get("title", ""),
+            "insight": insight,
+            "tags": item.get("tags", []),
+            "ts": now,
+            "source": "extraction",
+        })
+
+    state["knowledge_pending"] = pending[len(batch):]
+    log.info(
+        "[knowledge-base] Extracted %d insight(s) from %d post(s), %d queued",
+        len(entries), len(batch), len(state["knowledge_pending"]),
+    )
+    return entries
+
+
 def _record_knowledge(state: Dict[str, Any], entries: List[Dict[str, Any]]) -> None:
     """Persist knowledge entries, queueing the batch if the write fails.
 
-    The source posts are added to seen_post_ids before this runs, so a lost
-    batch is never regenerated -- later cycles skip those posts entirely.
+    The source posts have left the extraction queue by the time this runs, so
+    a lost batch is never regenerated.
     """
     from .knowledge_base import add_entries
 
@@ -610,6 +730,10 @@ def _trim_state(state: Dict[str, Any]) -> None:
     seen = state.get("seen_post_ids", [])
     if len(seen) > MAX_SEEN_POST_IDS:
         state["seen_post_ids"] = seen[-MAX_SEEN_POST_IDS:]
+
+    queued = state.get("knowledge_pending", [])
+    if len(queued) > MAX_KNOWLEDGE_PENDING:
+        state["knowledge_pending"] = queued[-MAX_KNOWLEDGE_PENDING:]
 
     _trim_comment_history(state, limit=MAX_COMMENT_HISTORY)
     _trim_self_question_log(state)
@@ -1083,12 +1207,19 @@ def run_loop() -> int:
                         state["last_comment_time"] = int(time.time())
                         last_comment_time = state["last_comment_time"]
 
+                # Insertion order matters: the cap is meant to keep the most
+                # recent ids, and list(set) order is arbitrary -- trimming that
+                # dropped ids at random, so old posts resurfaced as new. The
+                # cap also disagreed with _trim_state's, which then reapplied
+                # its own arbitrary slice.
+                seen_order = list(state.get("seen_post_ids", []))
                 for post in new_posts:
                     pid = post.get("id")
-                    if pid:
+                    if pid and pid not in seen:
                         seen.add(pid)
+                        seen_order.append(pid)
 
-                state["seen_post_ids"] = list(seen)[-500:]
+                state["seen_post_ids"] = seen_order[-MAX_SEEN_POST_IDS:]
                 state["last_check"] = int(time.time())
 
                 # -- Engagement tracking --
@@ -1108,7 +1239,11 @@ def run_loop() -> int:
                             log.exception("Engagement tracking failed")
 
                 # -- Knowledge base population --
-                if cfg.enable_knowledge_base and new_posts:
+                # Drain even with no new posts: the queue outlives the cycle
+                # that filled it, which is the whole point of having one.
+                if cfg.enable_knowledge_base and (
+                    new_posts or state.get("knowledge_pending")
+                ):
                     try:
                         from .knowledge_base import add_entries
 
@@ -1131,27 +1266,16 @@ def run_loop() -> int:
                                     "source": "comment",
                                 })
 
-                        # Remaining posts: batch extract via LLM
-                        overflow = [
+                        # Everything not commented on joins a durable queue.
+                        # The per-cycle LLM budget now bounds how many are
+                        # processed per pass, not how many are ever considered.
+                        _queue_for_extraction(state, [
                             p for p in new_posts
                             if p.get("id") not in commented_post_ids
-                        ]
-                        if overflow:
-                            batch_insights = llm.extract_insights_batch(
-                                openai_client, overflow[:5],
-                            )
-                            if batch_insights:
-                                for item in batch_insights:
-                                    idx = item.get("post_index", 0)
-                                    if 0 <= idx < len(overflow):
-                                        kb_entries.append({
-                                            "post_id": overflow[idx].get("id"),
-                                            "post_title": overflow[idx].get("title", ""),
-                                            "insight": item.get("insight", ""),
-                                            "tags": item.get("tags", []),
-                                            "ts": int(time.time()),
-                                            "source": "extraction",
-                                        })
+                        ])
+                        kb_entries.extend(
+                            _drain_extraction_queue(state, openai_client)
+                        )
 
                         if kb_entries:
                             _record_knowledge(state, kb_entries)

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -1268,6 +1268,11 @@ def run_loop() -> int:
                         state["last_comment_time"] = int(time.time())
                         last_comment_time = state["last_comment_time"]
 
+                # Nothing may save state between here and the extraction
+                # queueing below: a post recorded as seen but not yet queued is
+                # a post that is never extracted, which is the bug #67 is
+                # about. They reach disk in the same write.
+                #
                 # Insertion order matters: the cap is meant to keep the most
                 # recent ids, and list(set) order is arbitrary -- trimming that
                 # dropped ids at random, so old posts resurfaced as new. The
@@ -1347,18 +1352,22 @@ def run_loop() -> int:
                             # A batch that ran and found nothing is still a
                             # decision, so the posts still leave the queue.
                             _release_extracted(state, processed_ids)
-                        if processed_ids:
-                            # Checkpoint rather than waiting for the end of the
-                            # cycle: a crash in between would re-extract a
-                            # batch already recorded, paying for the LLM call
-                            # twice and duplicating the entries.
-                            try:
-                                save_state(state)
-                            except Exception:
-                                log.warning(
-                                    "Could not checkpoint the extraction queue",
-                                    exc_info=True,
-                                )
+                        # Checkpoint unconditionally rather than waiting for
+                        # the end of the cycle. A crash before this would
+                        # re-extract a batch already recorded, paying for the
+                        # call twice; it would also roll back the failure
+                        # bookkeeping -- attempt counts and posts given up on --
+                        # so a poisoned batch would get its three tries again
+                        # on every restart. This write is also what puts the
+                        # queue on disk alongside the seen_post_ids that
+                        # decided what entered it.
+                        try:
+                            save_state(state)
+                        except Exception:
+                            log.warning(
+                                "Could not checkpoint the extraction queue",
+                                exc_info=True,
+                            )
                     except Exception:
                         log.exception("Knowledge base population failed")
 

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -562,7 +562,9 @@ def _queue_for_extraction(state: Dict[str, Any], posts: List[Dict[str, Any]]) ->
         known.add(pid)
         pending.append({
             "id": pid,
-            "title": post.get("title", ""),
+            # `or ""`, not a get default: an explicit null title would
+            # otherwise reach the prompt as the literal "None".
+            "title": post.get("title") or "",
             "content": (post.get("content") or "")[:MAX_PENDING_CONTENT_CHARS],
             "attempts": 0,
         })

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -567,25 +567,19 @@ def _queue_for_extraction(state: Dict[str, Any], posts: List[Dict[str, Any]]) ->
             "attempts": 0,
         })
         added += 1
-
-    excess = len(pending) - MAX_KNOWLEDGE_PENDING
-    if excess > 0:
-        dropped = pending[:excess]
-        del pending[:excess]
-        # Named, not silent: a dropped post is one the agent will never learn
-        # from, and that is the bug this queue exists to fix.
-        log.warning(
-            "[knowledge-base] Queue over %d; dropped %d oldest: %s",
-            MAX_KNOWLEDGE_PENDING, len(dropped),
-            ", ".join(str(e.get("id")) for e in dropped),
-        )
+    # The cap is enforced in _trim_state, at save time. Evicting here would
+    # drop the head of the queue -- the exact batch about to be drained.
     return added
 
 
 def _drain_extraction_queue(
     state: Dict[str, Any], client: Any, limit: int = KNOWLEDGE_BATCH_SIZE
-) -> List[Dict[str, Any]]:
-    """Extract insights for the head of the queue and return the entries.
+) -> "tuple[List[Dict[str, Any]], List[Any]]":
+    """Extract insights for the head of the queue.
+
+    Returns (entries, processed_ids). The caller records the entries and then
+    calls _release_extracted with the ids -- the queue is not the record, so a
+    post may only leave it once its insight is somewhere durable.
 
     A post leaves the queue once it has a decision: an insight, or a batch
     that ran and found none. extract_insights_batch returns None only when the
@@ -596,10 +590,18 @@ def _drain_extraction_queue(
 
     pending = state.get("knowledge_pending") or []
     if not pending:
-        return []
+        return [], []
 
     batch = pending[:limit]
-    insights = llm.extract_insights_batch(client, batch)
+    try:
+        insights = llm.extract_insights_batch(client, batch)
+    except Exception:
+        # extract_insights_batch returns None on failure today, but the
+        # queue's guarantee that it cannot wedge should not depend on that
+        # staying true: an escaping exception would leave attempts at zero and
+        # retry the same head forever.
+        log.warning("[knowledge-base] Extraction raised", exc_info=True)
+        insights = None
 
     if not isinstance(insights, list):
         # None is the failure sentinel; anything else non-list means the reply
@@ -622,7 +624,7 @@ def _drain_extraction_queue(
                 "[knowledge-base] Extraction failed; %d post(s) stay queued",
                 len(batch),
             )
-        return []
+        return [], []
 
     entries: List[Dict[str, Any]] = []
     now = int(time.time())
@@ -647,12 +649,28 @@ def _drain_extraction_queue(
             "source": "extraction",
         })
 
-    state["knowledge_pending"] = pending[len(batch):]
     log.info(
         "[knowledge-base] Extracted %d insight(s) from %d post(s), %d queued",
-        len(entries), len(batch), len(state["knowledge_pending"]),
+        len(entries), len(batch), len(pending) - len(batch),
     )
-    return entries
+    return entries, [e.get("id") for e in batch]
+
+
+def _release_extracted(state: Dict[str, Any], post_ids: List[Any]) -> None:
+    """Drop posts from the queue once their insights are accounted for.
+
+    Called after _record_knowledge, which either persists the batch or queues
+    it in the durable outbox -- so by then the insight cannot be lost. Removing
+    them inside the drain instead left a window where an exception between
+    extracting and recording lost both.
+    """
+    if not post_ids:
+        return
+    done = set(post_ids)
+    state["knowledge_pending"] = [
+        entry for entry in state.get("knowledge_pending", [])
+        if entry.get("id") not in done
+    ]
 
 
 def _record_knowledge(state: Dict[str, Any], entries: List[Dict[str, Any]]) -> None:
@@ -733,7 +751,17 @@ def _trim_state(state: Dict[str, Any]) -> None:
 
     queued = state.get("knowledge_pending", [])
     if len(queued) > MAX_KNOWLEDGE_PENDING:
+        # Named, not silent: a dropped post is one the agent will never learn
+        # from, which is the bug this queue exists to fix. The newest are kept
+        # -- reaching the cap means being a long way behind, and by then a
+        # fresh post is worth more than one from twenty hours ago.
+        dropped = queued[:-MAX_KNOWLEDGE_PENDING]
         state["knowledge_pending"] = queued[-MAX_KNOWLEDGE_PENDING:]
+        log.warning(
+            "[knowledge-base] Queue over %d; dropped %d oldest: %s",
+            MAX_KNOWLEDGE_PENDING, len(dropped),
+            ", ".join(str(e.get("id")) for e in dropped),
+        )
 
     _trim_comment_history(state, limit=MAX_COMMENT_HISTORY)
     _trim_self_question_log(state)
@@ -1273,12 +1301,16 @@ def run_loop() -> int:
                             p for p in new_posts
                             if p.get("id") not in commented_post_ids
                         ])
-                        kb_entries.extend(
-                            _drain_extraction_queue(state, openai_client)
+                        extracted, processed_ids = _drain_extraction_queue(
+                            state, openai_client
                         )
+                        kb_entries.extend(extracted)
 
                         if kb_entries:
                             _record_knowledge(state, kb_entries)
+                        # Only now: _record_knowledge has either written the
+                        # entries or queued them in the outbox.
+                        _release_extracted(state, processed_ids)
                     except Exception:
                         log.exception("Knowledge base population failed")
 

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -592,6 +592,12 @@ def _drain_extraction_queue(
     if not pending:
         return [], []
 
+    for entry in pending:
+        # The loop is single-threaded, so nothing is legitimately in flight
+        # when a drain starts. Clearing first means a mark left behind by an
+        # interrupted cycle cannot outlive it.
+        entry.pop("in_flight", None)
+
     batch = pending[:limit]
     for entry in batch:
         # _record_knowledge saves state on a write failure, and save_state
@@ -683,20 +689,30 @@ def _release_extracted(state: Dict[str, Any], post_ids: List[Any]) -> None:
     ]
 
 
-def _record_knowledge(state: Dict[str, Any], entries: List[Dict[str, Any]]) -> None:
+def _record_knowledge(
+    state: Dict[str, Any],
+    entries: List[Dict[str, Any]],
+    processed_ids: Optional[List[Any]] = None,
+) -> None:
     """Persist knowledge entries, queueing the batch if the write fails.
 
-    The source posts have left the extraction queue by the time this runs, so
-    a lost batch is never regenerated.
+    Releases processed_ids from the extraction queue in the same step. The two
+    have to be one step: the failure path saves state, and if the queue still
+    held the posts at that moment, a crash straight after would leave the disk
+    holding both the insights in the outbox and the posts still pending --
+    extracting and recording them a second time on restart.
     """
     from .knowledge_base import add_entries
 
     try:
         add_entries(entries)
         log.info("[knowledge-base] Added %d entries", len(entries))
+        _release_extracted(state, processed_ids or [])
     except Exception:
         log.warning("Could not persist knowledge entries; queued", exc_info=True)
         state.setdefault("knowledge_outbox", []).extend(entries)
+        # The outbox owns them now, so the queue must let go before the save.
+        _release_extracted(state, processed_ids or [])
         try:
             save_state(state)
         except Exception:
@@ -1324,10 +1340,13 @@ def run_loop() -> int:
                         kb_entries.extend(extracted)
 
                         if kb_entries:
-                            _record_knowledge(state, kb_entries)
-                        # Only now: _record_knowledge has either written the
-                        # entries or queued them in the outbox.
-                        _release_extracted(state, processed_ids)
+                            # Releases the batch itself, once the entries are
+                            # either written or in the durable outbox.
+                            _record_knowledge(state, kb_entries, processed_ids)
+                        else:
+                            # A batch that ran and found nothing is still a
+                            # decision, so the posts still leave the queue.
+                            _release_extracted(state, processed_ids)
                         if processed_ids:
                             # Checkpoint rather than waiting for the end of the
                             # cycle: a crash in between would re-extract a

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -777,11 +777,22 @@ def _trim_state(state: Dict[str, Any]) -> None:
 
     queued = state.get("knowledge_pending", [])
     if len(queued) > MAX_KNOWLEDGE_PENDING:
-        # A batch mid-extraction is never a candidate: it is about to be
-        # released, and evicting it would lose an insight already paid for.
-        in_flight = [e for e in queued if e.get("in_flight")]
-        rest = [e for e in queued if not e.get("in_flight")]
-        room = max(0, MAX_KNOWLEDGE_PENDING - len(in_flight))
+        # Two kinds of entry are never candidates. A batch mid-extraction is
+        # about to be released, and evicting it would lose an insight already
+        # paid for. A batch part-way through its retries sits at the head, so
+        # the cap would drop it before the next attempt -- voiding the
+        # three-attempt rule precisely when it matters, since a sustained
+        # extraction outage is what saturates the queue in the first place.
+        #
+        # Only the head batch is ever retried, so this can protect at most one
+        # batch; the slice makes that a bound rather than an assumption.
+        def _protected(entry):
+            return entry.get("in_flight") or entry.get("attempts")
+
+        keep = [e for e in queued if _protected(e)][:KNOWLEDGE_BATCH_SIZE]
+        held = {id(e) for e in keep}
+        rest = [e for e in queued if id(e) not in held]
+        room = max(0, MAX_KNOWLEDGE_PENDING - len(keep))
         dropped = rest[:-room] if room else rest
         if dropped:
             # Named, not silent: a dropped post is one the agent never learns
@@ -794,7 +805,7 @@ def _trim_state(state: Dict[str, Any]) -> None:
                 MAX_KNOWLEDGE_PENDING, len(dropped),
                 ", ".join(str(e.get("id")) for e in dropped),
             )
-        state["knowledge_pending"] = in_flight + (rest[-room:] if room else [])
+        state["knowledge_pending"] = keep + (rest[-room:] if room else [])
 
     _trim_comment_history(state, limit=MAX_COMMENT_HISTORY)
     _trim_self_question_log(state)

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -480,9 +480,12 @@ def test_posts_beyond_the_batch_budget_stay_queued_rather_than_being_dropped():
         llm_mod, "extract_insights_batch",
         return_value=[{"post_index": 0, "insight": "i0", "tags": []}],
     ):
-        entries = moltbook._drain_extraction_queue(state, object())
+        entries, processed = moltbook._drain_extraction_queue(state, object())
 
     assert [e["post_id"] for e in entries] == ["p1"]
+    # Still queued until released -- the queue is not the record.
+    assert len(state["knowledge_pending"]) == 10
+    moltbook._release_extracted(state, processed)
     # The five that were processed are gone; the other five are still waiting.
     assert [e["id"] for e in state["knowledge_pending"]] == [
         "p6", "p7", "p8", "p9", "p10"
@@ -502,7 +505,8 @@ def test_the_queue_drains_across_cycles_until_empty():
 
     with mock.patch.object(llm_mod, "extract_insights_batch", side_effect=record):
         for _ in range(3):
-            moltbook._drain_extraction_queue(state, object())
+            _, processed = moltbook._drain_extraction_queue(state, object())
+            moltbook._release_extracted(state, processed)
 
     assert seen_batches == [
         ["p1", "p2", "p3", "p4", "p5"],
@@ -520,7 +524,9 @@ def test_a_batch_that_found_nothing_still_clears_the_queue():
     state = {}
     moltbook._queue_for_extraction(state, _posts(3))
     with mock.patch.object(llm_mod, "extract_insights_batch", return_value=[]):
-        assert moltbook._drain_extraction_queue(state, object()) == []
+        entries, processed = moltbook._drain_extraction_queue(state, object())
+    assert entries == []
+    moltbook._release_extracted(state, processed)
     assert state["knowledge_pending"] == []
 
 
@@ -530,7 +536,8 @@ def test_a_failed_extraction_leaves_the_posts_queued():
     state = {}
     moltbook._queue_for_extraction(state, _posts(3))
     with mock.patch.object(llm_mod, "extract_insights_batch", return_value=None):
-        assert moltbook._drain_extraction_queue(state, object()) == []
+        entries, processed = moltbook._drain_extraction_queue(state, object())
+    assert (entries, processed) == ([], [])
 
     assert [e["id"] for e in state["knowledge_pending"]] == ["p1", "p2", "p3"]
     assert [e["attempts"] for e in state["knowledge_pending"]] == [1, 1, 1]
@@ -542,7 +549,7 @@ def test_an_unparseable_reply_counts_as_a_failure_not_a_decision():
     state = {}
     moltbook._queue_for_extraction(state, _posts(2))
     with mock.patch.object(llm_mod, "extract_insights_batch", return_value="nonsense"):
-        assert moltbook._drain_extraction_queue(state, object()) == []
+        assert moltbook._drain_extraction_queue(state, object()) == ([], [])
     assert len(state["knowledge_pending"]) == 2
 
 
@@ -565,7 +572,7 @@ def test_a_permanently_failing_batch_does_not_block_the_queue_forever():
         llm_mod, "extract_insights_batch",
         return_value=[{"post_index": 1, "insight": "i7", "tags": []}],
     ):
-        entries = moltbook._drain_extraction_queue(state, object())
+        entries, _ = moltbook._drain_extraction_queue(state, object())
     assert [e["post_id"] for e in entries] == ["p7"]
 
 
@@ -579,17 +586,60 @@ def test_queueing_the_same_post_twice_does_not_duplicate_it():
 
 
 def test_the_queue_is_bounded_and_says_what_it_dropped(caplog):
+    """The cap is applied at save time, not on enqueue: evicting during
+    enqueue dropped the head, which is the batch about to be drained."""
+    from ouroboros import moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(
+        state, _posts(moltbook.MAX_KNOWLEDGE_PENDING + 3)
+    )
+    # Nothing dropped yet -- this cycle's drain still gets the oldest.
+    assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING + 3
+
+    with caplog.at_level("WARNING"):
+        moltbook._trim_state(state)
+
+    assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING
+    assert [e["id"] for e in state["knowledge_pending"][:2]] == ["p4", "p5"]
+    assert "dropped 3 oldest" in caplog.text
+
+
+def test_the_cap_never_evicts_the_batch_about_to_be_drained(caplog):
     from ouroboros import llm as llm_mod, moltbook
 
     state = {}
-    with caplog.at_level("WARNING"):
-        moltbook._queue_for_extraction(
-            state, _posts(moltbook.MAX_KNOWLEDGE_PENDING + 3)
-        )
-    assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING
-    # Oldest go first, and the drop is named rather than silent.
-    assert [e["id"] for e in state["knowledge_pending"][:2]] == ["p4", "p5"]
-    assert "dropped 3 oldest" in caplog.text
+    moltbook._queue_for_extraction(
+        state, _posts(moltbook.MAX_KNOWLEDGE_PENDING + 3)
+    )
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=[]):
+        _, processed = moltbook._drain_extraction_queue(state, object())
+
+    # The oldest five reached the LLM before any cap was applied.
+    assert processed == ["p1", "p2", "p3", "p4", "p5"]
+
+
+def test_an_exception_from_the_extractor_still_counts_as_an_attempt():
+    """The queue's guarantee that it cannot wedge must not depend on the
+    extractor's own try/except staying in place."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch", side_effect=RuntimeError("boom")
+    ):
+        assert moltbook._drain_extraction_queue(state, object()) == ([], [])
+    assert [e["attempts"] for e in state["knowledge_pending"]] == [1, 1]
+
+
+def test_release_is_a_no_op_for_an_empty_batch():
+    from ouroboros import moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    moltbook._release_extracted(state, [])
+    assert len(state["knowledge_pending"]) == 2
 
 
 def test_queued_post_content_is_capped():
@@ -618,7 +668,7 @@ def test_draining_an_empty_queue_makes_no_llm_call():
     from ouroboros import llm as llm_mod, moltbook
 
     with mock.patch.object(llm_mod, "extract_insights_batch") as call:
-        assert moltbook._drain_extraction_queue({}, object()) == []
+        assert moltbook._drain_extraction_queue({}, object()) == ([], [])
     call.assert_not_called()
 
 
@@ -637,9 +687,10 @@ def test_out_of_range_and_malformed_insight_items_are_ignored():
             {"post_index": 1, "insight": "kept", "tags": ["t"]},
         ],
     ):
-        entries = moltbook._drain_extraction_queue(state, object())
+        entries, processed = moltbook._drain_extraction_queue(state, object())
 
     assert [e["post_id"] for e in entries] == ["p2"]
+    moltbook._release_extracted(state, processed)
     assert state["knowledge_pending"] == []
 
 
@@ -671,3 +722,44 @@ def test_trim_state_bounds_the_extraction_queue():
     assert state["knowledge_pending"][-1]["id"] == (
         f"p{moltbook.MAX_KNOWLEDGE_PENDING + 9}"
     )
+
+
+def test_a_failed_knowledge_write_outboxes_the_entries_and_releases_the_posts():
+    """_record_knowledge either writes or queues in the durable outbox, so by
+    the time it returns the insight cannot be lost and the post may leave the
+    queue. This is the ordering run_loop relies on."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch",
+        return_value=[{"post_index": 0, "insight": "i1", "tags": []}],
+    ):
+        entries, processed = moltbook._drain_extraction_queue(state, object())
+
+    with mock.patch(
+        "ouroboros.knowledge_base.add_entries", side_effect=OSError("disk full")
+    ), mock.patch.object(moltbook, "save_state"):
+        moltbook._record_knowledge(state, entries)
+    moltbook._release_extracted(state, processed)
+
+    assert [e["insight"] for e in state["knowledge_outbox"]] == ["i1"]
+    assert state["knowledge_pending"] == []
+
+
+def test_a_post_is_not_released_if_recording_never_ran():
+    """The window the two-phase split closes: an exception between extracting
+    and recording used to lose both the insight and the post."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch",
+        return_value=[{"post_index": 0, "insight": "i1", "tags": []}],
+    ):
+        moltbook._drain_extraction_queue(state, object())
+        # _release_extracted is never reached.
+
+    assert [e["id"] for e in state["knowledge_pending"]] == ["p1", "p2"]

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -738,14 +738,22 @@ def test_a_failed_knowledge_write_outboxes_the_entries_and_releases_the_posts():
     ):
         entries, processed = moltbook._drain_extraction_queue(state, object())
 
+    seen_on_disk = {}
+
+    def capture(st):
+        seen_on_disk["pending"] = [e["id"] for e in st.get("knowledge_pending", [])]
+        seen_on_disk["outbox"] = [e["insight"] for e in st.get("knowledge_outbox", [])]
+
     with mock.patch(
         "ouroboros.knowledge_base.add_entries", side_effect=OSError("disk full")
-    ), mock.patch.object(moltbook, "save_state"):
-        moltbook._record_knowledge(state, entries)
-    moltbook._release_extracted(state, processed)
+    ), mock.patch.object(moltbook, "save_state", side_effect=capture):
+        moltbook._record_knowledge(state, entries, processed)
 
     assert [e["insight"] for e in state["knowledge_outbox"]] == ["i1"]
     assert state["knowledge_pending"] == []
+    # The point: what reached disk cannot hold the posts *and* their insights.
+    # A crash right after would otherwise extract and record them twice.
+    assert seen_on_disk == {"pending": [], "outbox": ["i1"]}
 
 
 def test_a_post_is_not_released_if_recording_never_ran():
@@ -817,3 +825,39 @@ def test_release_does_not_purge_entries_whose_id_is_missing():
     ]}
     moltbook._release_extracted(state, [None])
     assert len(state["knowledge_pending"]) == 2
+
+
+def test_a_successful_write_releases_the_batch_in_the_same_step():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch",
+        return_value=[{"post_index": 0, "insight": "i1", "tags": []}],
+    ):
+        entries, processed = moltbook._drain_extraction_queue(state, object())
+
+    with mock.patch("ouroboros.knowledge_base.add_entries") as add:
+        moltbook._record_knowledge(state, entries, processed)
+
+    add.assert_called_once()
+    assert state["knowledge_pending"] == []
+
+
+def test_a_stale_in_flight_mark_does_not_outlive_the_cycle():
+    """If a cycle is interrupted between extracting and releasing, the mark is
+    left behind. It must not make those entries immune to the cap forever."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {"knowledge_pending": [
+        {"id": "stale", "title": "", "content": "", "attempts": 0,
+         "in_flight": True},
+        {"id": "fresh", "title": "", "content": "", "attempts": 0},
+    ]}
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=[]):
+        _, processed = moltbook._drain_extraction_queue(state, object())
+
+    assert processed == ["stale", "fresh"]
+    moltbook._release_extracted(state, processed)
+    assert state["knowledge_pending"] == []

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -455,3 +455,219 @@ def test_load_state_unreadable_does_not_reset_to_default(tmp_path):
                 load_state()
 
     assert json.loads(state_file.read_text())["seen_post_ids"] == ["a"]
+
+
+# -- feed visibility is not knowledge processing (#67) -----------------------
+
+def _posts(n, start=1):
+    return [
+        {"id": f"p{i}", "title": f"t{i}", "content": f"c{i}"}
+        for i in range(start, start + n)
+    ]
+
+
+def test_posts_beyond_the_batch_budget_stay_queued_rather_than_being_dropped():
+    """The bug: with ten posts a fetch, the sixth uncommented one was marked
+    seen without ever reaching extraction, and never came back."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    added = moltbook._queue_for_extraction(state, _posts(10))
+    assert added == 10
+    assert len(state["knowledge_pending"]) == 10
+
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch",
+        return_value=[{"post_index": 0, "insight": "i0", "tags": []}],
+    ):
+        entries = moltbook._drain_extraction_queue(state, object())
+
+    assert [e["post_id"] for e in entries] == ["p1"]
+    # The five that were processed are gone; the other five are still waiting.
+    assert [e["id"] for e in state["knowledge_pending"]] == [
+        "p6", "p7", "p8", "p9", "p10"
+    ]
+
+
+def test_the_queue_drains_across_cycles_until_empty():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(12))
+    seen_batches = []
+
+    def record(_client, batch, *a, **kw):
+        seen_batches.append([p["id"] for p in batch])
+        return []
+
+    with mock.patch.object(llm_mod, "extract_insights_batch", side_effect=record):
+        for _ in range(3):
+            moltbook._drain_extraction_queue(state, object())
+
+    assert seen_batches == [
+        ["p1", "p2", "p3", "p4", "p5"],
+        ["p6", "p7", "p8", "p9", "p10"],
+        ["p11", "p12"],
+    ]
+    assert state["knowledge_pending"] == []
+
+
+def test_a_batch_that_found_nothing_still_clears_the_queue():
+    """[] means the extraction ran and found nothing -- a decision. Only None
+    means it failed."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(3))
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=[]):
+        assert moltbook._drain_extraction_queue(state, object()) == []
+    assert state["knowledge_pending"] == []
+
+
+def test_a_failed_extraction_leaves_the_posts_queued():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(3))
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=None):
+        assert moltbook._drain_extraction_queue(state, object()) == []
+
+    assert [e["id"] for e in state["knowledge_pending"]] == ["p1", "p2", "p3"]
+    assert [e["attempts"] for e in state["knowledge_pending"]] == [1, 1, 1]
+
+
+def test_an_unparseable_reply_counts_as_a_failure_not_a_decision():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value="nonsense"):
+        assert moltbook._drain_extraction_queue(state, object()) == []
+    assert len(state["knowledge_pending"]) == 2
+
+
+def test_a_permanently_failing_batch_does_not_block_the_queue_forever():
+    """Without an attempt cap the head of a FIFO queue that always fails means
+    nothing behind it is ever extracted."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(7))
+
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=None):
+        for _ in range(moltbook.MAX_EXTRACTION_ATTEMPTS):
+            moltbook._drain_extraction_queue(state, object())
+
+    # The poisoned head is dropped; what was behind it survives.
+    assert [e["id"] for e in state["knowledge_pending"]] == ["p6", "p7"]
+
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch",
+        return_value=[{"post_index": 1, "insight": "i7", "tags": []}],
+    ):
+        entries = moltbook._drain_extraction_queue(state, object())
+    assert [e["post_id"] for e in entries] == ["p7"]
+
+
+def test_queueing_the_same_post_twice_does_not_duplicate_it():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(3))
+    assert moltbook._queue_for_extraction(state, _posts(3)) == 0
+    assert [e["id"] for e in state["knowledge_pending"]] == ["p1", "p2", "p3"]
+
+
+def test_the_queue_is_bounded_and_says_what_it_dropped(caplog):
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    with caplog.at_level("WARNING"):
+        moltbook._queue_for_extraction(
+            state, _posts(moltbook.MAX_KNOWLEDGE_PENDING + 3)
+        )
+    assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING
+    # Oldest go first, and the drop is named rather than silent.
+    assert [e["id"] for e in state["knowledge_pending"][:2]] == ["p4", "p5"]
+    assert "dropped 3 oldest" in caplog.text
+
+
+def test_queued_post_content_is_capped():
+    """The queue is persisted with the rest of state; an unbounded copy of
+    every post body would bloat it."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(
+        state, [{"id": "big", "title": "t", "content": "x" * 50_000}]
+    )
+    assert len(state["knowledge_pending"][0]["content"]) == (
+        moltbook.MAX_PENDING_CONTENT_CHARS
+    )
+
+
+def test_a_post_with_no_id_is_not_queued():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    assert moltbook._queue_for_extraction(state, [{"title": "no id"}]) == 0
+    assert state["knowledge_pending"] == []
+
+
+def test_draining_an_empty_queue_makes_no_llm_call():
+    from ouroboros import llm as llm_mod, moltbook
+
+    with mock.patch.object(llm_mod, "extract_insights_batch") as call:
+        assert moltbook._drain_extraction_queue({}, object()) == []
+    call.assert_not_called()
+
+
+def test_out_of_range_and_malformed_insight_items_are_ignored():
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch",
+        return_value=[
+            {"post_index": 99, "insight": "out of range"},
+            {"post_index": "nope", "insight": "unparseable index"},
+            "not a dict",
+            {"post_index": 0, "insight": ""},          # empty insight
+            {"post_index": 1, "insight": "kept", "tags": ["t"]},
+        ],
+    ):
+        entries = moltbook._drain_extraction_queue(state, object())
+
+    assert [e["post_id"] for e in entries] == ["p2"]
+    assert state["knowledge_pending"] == []
+
+
+def test_trim_state_keeps_the_most_recent_seen_ids_in_order():
+    """The cap is meant to keep recent ids. The old code sliced list(set(...)),
+    whose order is arbitrary, so it discarded at random and old posts came
+    back as new."""
+    from ouroboros import moltbook
+
+    ids = [f"p{i}" for i in range(moltbook.MAX_SEEN_POST_IDS + 25)]
+    state = {"seen_post_ids": list(ids)}
+    moltbook._trim_state(state)
+
+    assert state["seen_post_ids"] == ids[-moltbook.MAX_SEEN_POST_IDS:]
+    assert state["seen_post_ids"][-1] == ids[-1]
+
+
+def test_trim_state_bounds_the_extraction_queue():
+    from ouroboros import moltbook
+
+    state = {
+        "knowledge_pending": [
+            {"id": f"p{i}", "title": "", "content": "", "attempts": 0}
+            for i in range(moltbook.MAX_KNOWLEDGE_PENDING + 10)
+        ]
+    }
+    moltbook._trim_state(state)
+    assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING
+    assert state["knowledge_pending"][-1]["id"] == (
+        f"p{moltbook.MAX_KNOWLEDGE_PENDING + 9}"
+    )

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -763,3 +763,57 @@ def test_a_post_is_not_released_if_recording_never_ran():
         # _release_extracted is never reached.
 
     assert [e["id"] for e in state["knowledge_pending"]] == ["p1", "p2"]
+
+
+def test_the_cap_never_evicts_a_batch_that_is_mid_extraction():
+    """_record_knowledge saves on a write failure, and save_state trims -- with
+    the batch still queued, because release comes after recording. Evicting it
+    there would lose an insight already paid for."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(
+        state, _posts(moltbook.MAX_KNOWLEDGE_PENDING + 20)
+    )
+
+    def trim_midway(_client, batch, *a, **kw):
+        # Stand in for the save_state that _record_knowledge performs.
+        moltbook._trim_state(state)
+        return [{"post_index": 0, "insight": "i", "tags": []}]
+
+    with mock.patch.object(
+        llm_mod, "extract_insights_batch", side_effect=trim_midway
+    ):
+        entries, processed = moltbook._drain_extraction_queue(state, object())
+
+    assert processed == ["p1", "p2", "p3", "p4", "p5"]
+    still_queued = {e["id"] for e in state["knowledge_pending"]}
+    assert set(processed) <= still_queued, "the in-flight batch was evicted"
+
+    moltbook._release_extracted(state, processed)
+    assert not (set(processed) & {e["id"] for e in state["knowledge_pending"]})
+    assert len(state["knowledge_pending"]) <= moltbook.MAX_KNOWLEDGE_PENDING
+
+
+def test_a_failed_batch_stops_being_in_flight():
+    """Otherwise a batch that failed would be immune to the cap forever."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(3))
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=None):
+        moltbook._drain_extraction_queue(state, object())
+
+    assert not any(e.get("in_flight") for e in state["knowledge_pending"])
+
+
+def test_release_does_not_purge_entries_whose_id_is_missing():
+    """None in the released set would match every id-less entry at once."""
+    from ouroboros import moltbook
+
+    state = {"knowledge_pending": [
+        {"id": "keep", "title": "", "content": "", "attempts": 0},
+        {"title": "no id at all", "content": "", "attempts": 0},
+    ]}
+    moltbook._release_extracted(state, [None])
+    assert len(state["knowledge_pending"]) == 2

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -863,10 +863,10 @@ def test_a_stale_in_flight_mark_does_not_outlive_the_cycle():
     assert state["knowledge_pending"] == []
 
 
-def test_failure_bookkeeping_is_checkpointed_not_only_held_in_memory():
-    """Attempt counts and give-ups must survive a restart. If they only reached
-    disk at the end of the cycle, a poisoned batch would get three fresh tries
-    every time the process came back."""
+def test_failure_bookkeeping_lands_in_state_and_survives_serialisation():
+    """Attempt counts have to reach disk for the give-up rule to mean anything
+    across a restart, so they must live in state and round-trip through JSON.
+    That run_loop checkpoints them is the caller's half; this is the data's."""
     from ouroboros import llm as llm_mod, moltbook
 
     state = {}
@@ -878,3 +878,53 @@ def test_failure_bookkeeping_is_checkpointed_not_only_held_in_memory():
     persisted = json.loads(json.dumps(state))
     assert [e["attempts"] for e in persisted["knowledge_pending"]] == [1, 1]
     assert not any(e.get("in_flight") for e in persisted["knowledge_pending"])
+
+
+def test_the_retry_rule_survives_a_saturated_queue():
+    """A sustained extraction outage is what saturates the queue, so the cap
+    and the retry rule collide exactly when retries matter. The cap used to
+    drop the failed batch off the head before its second attempt, making
+    MAX_EXTRACTION_ATTEMPTS dead letter under load."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(
+        state, _posts(moltbook.MAX_KNOWLEDGE_PENDING + 10)
+    )
+    head = ["p1", "p2", "p3", "p4", "p5"]
+
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=None):
+        for expected in range(1, moltbook.MAX_EXTRACTION_ATTEMPTS):
+            moltbook._drain_extraction_queue(state, object())
+            moltbook._trim_state(state)
+            attempts = {
+                e["id"]: e["attempts"]
+                for e in state["knowledge_pending"] if e["id"] in head
+            }
+            assert attempts == dict.fromkeys(head, expected), (
+                f"the batch was evicted before attempt {expected + 1}"
+            )
+            assert len(state["knowledge_pending"]) <= (
+                moltbook.MAX_KNOWLEDGE_PENDING
+            )
+
+        # The last attempt retires them through the give-up path, not the cap.
+        moltbook._drain_extraction_queue(state, object())
+        moltbook._trim_state(state)
+
+    remaining = {e["id"] for e in state["knowledge_pending"]}
+    assert not (set(head) & remaining)
+    assert "p16" in remaining, "the cap shed unprotected entries, as intended"
+
+
+def test_the_retry_exemption_cannot_grow_beyond_one_batch():
+    """Otherwise a sustained outage would exempt the whole queue from the cap
+    and it would grow without bound."""
+    from ouroboros import moltbook
+
+    state = {"knowledge_pending": [
+        {"id": f"p{i}", "title": "", "content": "", "attempts": 1}
+        for i in range(moltbook.MAX_KNOWLEDGE_PENDING + 50)
+    ]}
+    moltbook._trim_state(state)
+    assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -861,3 +861,20 @@ def test_a_stale_in_flight_mark_does_not_outlive_the_cycle():
     assert processed == ["stale", "fresh"]
     moltbook._release_extracted(state, processed)
     assert state["knowledge_pending"] == []
+
+
+def test_failure_bookkeeping_is_checkpointed_not_only_held_in_memory():
+    """Attempt counts and give-ups must survive a restart. If they only reached
+    disk at the end of the cycle, a poisoned batch would get three fresh tries
+    every time the process came back."""
+    from ouroboros import llm as llm_mod, moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(state, _posts(2))
+    with mock.patch.object(llm_mod, "extract_insights_batch", return_value=None):
+        moltbook._drain_extraction_queue(state, object())
+
+    # What a save would write, not just what the object holds.
+    persisted = json.loads(json.dumps(state))
+    assert [e["attempts"] for e in persisted["knowledge_pending"]] == [1, 1]
+    assert not any(e.get("in_flight") for e in persisted["knowledge_pending"])

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -928,3 +928,16 @@ def test_the_retry_exemption_cannot_grow_beyond_one_batch():
     ]}
     moltbook._trim_state(state)
     assert len(state["knowledge_pending"]) == moltbook.MAX_KNOWLEDGE_PENDING
+
+
+def test_a_null_title_is_normalised_like_a_null_body():
+    """A get default does not fire for an explicit null, so the title reached
+    the extraction prompt as the literal "None"."""
+    from ouroboros import moltbook
+
+    state = {}
+    moltbook._queue_for_extraction(
+        state, [{"id": "p1", "title": None, "content": None}]
+    )
+    assert state["knowledge_pending"][0]["title"] == ""
+    assert state["knowledge_pending"][0]["content"] == ""


### PR DESCRIPTION
Closes #67.

`seen_post_ids` answered two different questions — "already displayed" and "already considered for an insight" — with one list. Because they shared a list, the per-cycle LLM budget silently doubled as a cap on how many posts were ever *looked at*. A fetch returns up to ten posts; extraction covered the ones the agent commented on plus the first five uncommented ones, and every post was marked seen before that ran. The sixth uncommented post was checkpointed as seen without ever reaching extraction, and later cycles filter on seen, so it never came back. A transient extraction failure lost its whole batch the same way.

Posts now enter a durable `knowledge_pending` queue and leave it only once they have a **decision**: an insight, or a batch that ran and found none. `extract_insights_batch` already returned `None` for a failed call and a list otherwise, so a failure leaves the batch queued rather than dropping it. The budget bounds how many are processed per pass, not how many are ever considered, and the queue drains across cycles even when no new posts arrive.

## What the queue itself could have broken

A durable queue introduces its own ways to lose things. Four rounds of review found them:

- **A FIFO whose head always fails blocks everything behind it forever.** Attempts are counted per post and a batch is abandoned after three — named in the log, since a dropped post is one the agent never learns from. The extractor call is wrapped so an escaping exception counts as an attempt too: the guarantee that the queue cannot wedge shouldn't rest on a callee's internal `try/except` staying in place.
- **"Extracted" is not "recorded."** The drain used to remove the batch and then hand the entries back, so an exception in between lost both. `_record_knowledge` now takes the processed ids and releases them itself, on both branches — the failure path saves state, and if the queue still held the posts at that moment, a crash straight after would leave the disk holding the insights in the outbox *and* the posts still pending, extracting them a second time on restart.
- **The cap evicted what was about to be processed.** Overflow eviction ran during enqueue, immediately before the drain. It now runs in `_trim_state` at save time, and never touches a batch mid-extraction.
- **Failure bookkeeping wasn't durable.** The checkpoint was guarded on a batch having been processed, so attempt counts and give-ups lived only in memory until the end of the cycle. A poisoned batch would get three fresh tries on every restart.

## Adjacent bug fixed

The `seen` bookkeeping this sits on wrote `list(seen)[-500:]` where `seen` is a **set** — so the slice kept an arbitrary 500 ids rather than the most recent, and 500 disagreed with the 200 `_trim_state` then applied to its own arbitrary slice. Old posts could resurface as new. Insertion order is now preserved and one cap is used.

## Rejected

- That a failed knowledge write silently loses the batch — `_record_knowledge` doesn't raise; #12 gave it the outbox precisely so the entries survive. There's a test.
- That in-flight entries cause unbounded queue growth — `_trim_state` writes `in_flight + rest`, putting them at the head, so they're the next batch and release themselves. Fixed anyway, since relying on that is subtler than clearing the mark.
- That newly queued posts are already lost on a failed cycle — `seen_post_ids` and `knowledge_pending` are the same dict written by the same call, and nothing in the gap saves. They roll back together.

The path had no tests. It now has 27. 878 pass overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EctMqruGhEtygspBS172cG