### PR TITLE
[ouroboros] fix_bug: Fix parameter extraction in extract_code_metadata and get_fu

### DIFF
--- a/src/ouroboros/codebase.py
+++ b/src/ouroboros/codebase.py
@@ -37,6 +37,19 @@ class FileMetadata:
     imports: List[str] = field(default_factory=list)
 
 
+def _extract_args(args_node: ast.arguments) -> List[str]:
+    """Extract parameter names from an AST arguments node in Python order."""
+    params: List[str] = []
+    params.extend(arg.arg for arg in getattr(args_node, "posonlyargs", []))
+    params.extend(arg.arg for arg in args_node.args)
+    if args_node.vararg is not None:
+        params.append(f"*{args_node.vararg.arg}")
+    params.extend(arg.arg for arg in args_node.kwonlyargs)
+    if args_node.kwarg is not None:
+        params.append(f"**{args_node.kwarg.arg}")
+    return params
+
+
 def extract_code_metadata(content: str, path: str = "") -> FileMetadata:
     """Extract structural metadata from Python code using AST."""
     try:
@@ -58,7 +71,7 @@ def extract_code_metadata(content: str, path: str = "") -> FileMetadata:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             metadata.functions.append(FunctionMetadata(
                 name=node.name,
-                args=[arg.arg for arg in node.args.args],
+                args=_extract_args(node.args),
                 docstring=ast.get_docstring(node),
                 line_start=node.lineno,
                 line_end=getattr(node, "end_lineno", node.lineno)
@@ -74,7 +87,7 @@ def extract_code_metadata(content: str, path: str = "") -> FileMetadata:
                 if isinstance(subnode, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     cls.methods.append(FunctionMetadata(
                         name=subnode.name,
-                        args=[arg.arg for arg in subnode.args.args],
+                        args=_extract_args(subnode.args),
                         docstring=ast.get_docstring(subnode),
                         line_start=subnode.lineno,
                         line_end=getattr(subnode, "end_lineno", subnode.lineno)
@@ -164,7 +177,7 @@ def get_function_signatures(path: Path) -> List[Dict[str, Any]]:
         if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             sig: Dict[str, Any] = {
                 "name": node.name,
-                "args": [arg.arg for arg in node.args.args],
+                "args": _extract_args(node.args),
                 "line": node.lineno,
                 "type": "function",
             }

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -149,6 +149,53 @@ def test_get_function_signatures_async_method(tmp_path):
     ]
 
 
+def test_get_function_signatures_all_parameter_types(tmp_path):
+    test_file = tmp_path / 'params.py'
+    test_file.write_text(textwrap.dedent('''
+        def complex_func(pos_only, /, regular, *args, kw_only, **kwargs):
+            pass
+
+        def keyword_only_func(*, key_only=True, **kwargs):
+            pass
+
+        class Service:
+            def sync_method(self, raw, /, regular, *args, kw_only, **kwargs):
+                pass
+
+            async def async_method(self, first, /, second, *items, flag=False, **options):
+                pass
+    ''').lstrip())
+
+    assert get_function_signatures(test_file) == [
+        {
+            'name': 'complex_func',
+            'args': ['pos_only', 'regular', '*args', 'kw_only', '**kwargs'],
+            'line': 1,
+            'type': 'function',
+        },
+        {
+            'name': 'keyword_only_func',
+            'args': ['key_only', '**kwargs'],
+            'line': 4,
+            'type': 'function',
+        },
+        {
+            'name': 'sync_method',
+            'args': ['self', 'raw', 'regular', '*args', 'kw_only', '**kwargs'],
+            'line': 8,
+            'type': 'method',
+            'class': 'Service',
+        },
+        {
+            'name': 'async_method',
+            'args': ['self', 'first', 'second', '*items', 'flag', '**options'],
+            'line': 11,
+            'type': 'method',
+            'class': 'Service',
+        },
+    ]
+
+
 def test_get_function_signatures_preserves_breadth_first_order(tmp_path):
     """Shallower definitions are reported before deeper ones."""
     test_file = tmp_path / 'order.py'
@@ -211,6 +258,45 @@ def test_extract_code_metadata_async_functions_and_methods():
     refresh = service.methods[0]
     assert refresh.args == ["self", "key"]
     assert refresh.docstring == "Refresh one key."
+
+
+def test_extract_code_metadata_all_parameter_types():
+    code = textwrap.dedent('''
+        def complex_func(pos_only, /, regular, *args, kw_only, **kwargs):
+            pass
+
+        def keyword_only_func(*, key_only=True, **kwargs):
+            pass
+
+        class Service:
+            def sync_method(self, raw, /, regular, *args, kw_only, **kwargs):
+                pass
+
+            async def async_method(self, first, /, second, *items, flag=False, **options):
+                pass
+    ''').lstrip()
+
+    metadata = extract_code_metadata(code, "params.py")
+
+    assert [func.name for func in metadata.functions] == [
+        "complex_func", "keyword_only_func",
+    ]
+    assert metadata.functions[0].args == [
+        "pos_only", "regular", "*args", "kw_only", "**kwargs",
+    ]
+    assert metadata.functions[1].args == ["key_only", "**kwargs"]
+
+    assert len(metadata.classes) == 1
+    service = metadata.classes[0]
+    assert [method.name for method in service.methods] == [
+        "sync_method", "async_method",
+    ]
+    assert service.methods[0].args == [
+        "self", "raw", "regular", "*args", "kw_only", "**kwargs",
+    ]
+    assert service.methods[1].args == [
+        "self", "first", "second", "*items", "flag", "**options",
+    ]
 
 
 def test_get_codebase_summary_includes_async_metadata(tmp_path):


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: 42f22212

### Description
Fix parameter extraction in extract_code_metadata and get_function_signatures within src/ouroboros/codebase.py to include positional-only arguments (posonlyargs), keyword-only arguments (kwonlyargs), varargs (*args), and kwargs (**kwargs) instead of only node.args.args, and add unit test coverage in tests/test_codebase.py.

### Evidence
In src/ouroboros/codebase.py, extract_code_metadata (lines 61, 77) and get_function_signatures (line 167) extract arguments solely from node.args.args. Any function or method using positional-only arguments, keyword-only arguments (e.g. load_json_file(*, error_msg)), varargs (e.g. bundle(*vectors)), or kwargs has those arguments omitted from extracted metadata and codebase summaries.

### Changes
- `src/ouroboros/codebase.py`: Agent edit: src/ouroboros/codebase.py
- `tests/test_codebase.py`: Agent edit: tests/test_codebase.py

### Test Results
- **Before**: 966 passed, 0 failed, 0 errors (returncode=0), coverage=72.0%
- **After**: 968 passed, 0 failed, 0 errors (returncode=0), coverage=72.0%

---
Generated autonomously by Ouroboros self-improvement engine.