### PR TITLE
[ouroboros] fix_bug: Fix summary line parsing in _parse_pytest_output within src/

### DIFF
--- a/src/ouroboros/test_runner.py
+++ b/src/ouroboros/test_runner.py
@@ -50,22 +50,30 @@ def _parse_pytest_output(output: str) -> dict:
     """Parse pytest output into counts and failure details."""
     result = {"passed": 0, "failed": 0, "errors": 0, "failures": [], "coverage": None}
 
+    summary_line = ""
+    for line in reversed(output.splitlines()):
+        if re.search(r"\bin\s+\d+(?:\.\d+)?s\b", line):
+            summary_line = line
+            break
+
     # Handle case for 'no tests ran'
-    if 'no tests ran' in output:
+    if "no tests ran" in summary_line or "no tests ran" in output:
         return result
 
-    # Match summary line like "3 passed, 1 failed, 1 error in 0.52s"
-    summary_match = re.search(r"(\d+) passed", output)
-    if summary_match:
-        result["passed"] = int(summary_match.group(1))
+    if summary_line:
+        # Match counts from the terminal summary line only, e.g.
+        # "3 passed, 1 failed, 1 error in 0.52s".
+        summary_match = re.search(r"(\d+)\s+passed", summary_line)
+        if summary_match:
+            result["passed"] = int(summary_match.group(1))
 
-    failed_match = re.search(r"(\d+) failed", output)
-    if failed_match:
-        result["failed"] = int(failed_match.group(1))
+        failed_match = re.search(r"(\d+)\s+failed", summary_line)
+        if failed_match:
+            result["failed"] = int(failed_match.group(1))
 
-    error_match = re.search(r"(\d+) error", output)
-    if error_match:
-        result["errors"] = int(error_match.group(1))
+        error_match = re.search(r"(\d+)\s+error", summary_line)
+        if error_match:
+            result["errors"] = int(error_match.group(1))
 
     # Match coverage line like "TOTAL                                          1272    169    87%"
     cov_match = re.search(r"TOTAL\s+\d+\s+\d+\s+(\d+)%", output)

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -32,6 +32,51 @@ def test_parse_pytest_output_mixed():
     assert result["failed"] == 2
     assert result["errors"] == 1
 
+def test_parse_pytest_output_ignores_log_messages():
+    output = """
+tests/test_service.py::test_pipeline
+[INFO] Processed 100 passed records and 20 failed records, 5 errors encountered
+PASSED
+1 passed in 0.45s
+"""
+    result = _parse_pytest_output(output)
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    assert result["errors"] == 0
+
+def test_parse_pytest_output_terminal_summary_banner():
+    output = """
+[DEBUG] 50 passed items and 12 failed attempts
+=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_bar - AssertionError
+=================== 2 passed, 1 failed, 1 error in 1.50s ===================
+"""
+    result = _parse_pytest_output(output)
+    assert result["passed"] == 2
+    assert result["failed"] == 1
+    assert result["errors"] == 1
+    assert len(result["failures"]) == 1
+
+def test_parse_pytest_output_with_warnings():
+    output = """
+[DEBUG] 10 passed setup checks, 3 failed retries, 2 errors ignored
+=================== 4 passed, 2 warnings in 0.30s ===================
+"""
+    result = _parse_pytest_output(output)
+    assert result["passed"] == 4
+    assert result["failed"] == 0
+    assert result["errors"] == 0
+
+def test_parse_pytest_output_missing_summary_line():
+    output = """
+INTERNALERROR> RuntimeError: pytest crashed before writing its summary
+[DEBUG] 10 passed setup checks, 3 failed retries, 2 errors ignored
+"""
+    result = _parse_pytest_output(output)
+    assert result["passed"] == 0
+    assert result["failed"] == 0
+    assert result["errors"] == 0
+
 def test_parse_pytest_output_failed_details():
     output = """
 FAILED tests/test_foo.py::test_bar - AssertionError: expected 1 got 2


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: ba402fec

### Description
Fix summary line parsing in _parse_pytest_output within src/ouroboros/test_runner.py to match test counts specifically from the terminal pytest summary line (the line containing 'in <time>s') rather than using unanchored regexes across full stdout, preventing test log messages containing 'passed' or 'failed' from corrupting pass/fail counts, and add unit test coverage in tests/test_test_runner.py.

### Evidence
In _parse_pytest_output within src/ouroboros/test_runner.py, re.search(r'(\d+) passed', output) searches the entire unanchored output string from the beginning, matching the first occurrence in test logs or assertion messages (e.g. '10 passed checks') instead of the actual pytest summary line at the end of the test run.

### Changes
- `src/ouroboros/test_runner.py`: Agent edit: src/ouroboros/test_runner.py
- `tests/test_test_runner.py`: Agent edit: tests/test_test_runner.py

### Test Results
- **Before**: 968 passed, 0 failed, 0 errors (returncode=0), coverage=72.0%
- **After**: 972 passed, 0 failed, 0 errors (returncode=0), coverage=72.0%

---
Generated autonomously by Ouroboros self-improvement engine.