### PR TITLE
[ouroboros] fix_bug: Fix _fts_candidates in FactRetriever within src/ouroboros/me

### DIFF
--- a/src/ouroboros/memory.py
+++ b/src/ouroboros/memory.py
@@ -761,8 +761,11 @@ class FactRetriever:
 
     def _fts_candidates(self, query: str, category: Optional[str],
                         min_trust: float, limit: int) -> List[Dict]:
+        match_query = _fts5_match_query(query)
+        if not match_query:
+            return []
         conn = self.store._conn
-        params: list = [query]
+        params: list = [match_query]
         where_parts = ["facts_fts MATCH ?"]
         if category:
             where_parts.append("f.category = ?")
@@ -778,10 +781,7 @@ class FactRetriever:
             WHERE {' AND '.join(where_parts)}
             ORDER BY facts_fts.rank LIMIT ?
         """
-        try:
-            rows = conn.execute(sql, params).fetchall()
-        except Exception:
-            return []
+        rows = conn.execute(sql, params).fetchall()
         if not rows:
             return []
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -298,6 +298,89 @@ def test_search_facts_no_hits_does_not_bump_retrieval_count(temp_store):
     assert stored["retrieval_count"] == 0
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "col:val",
+        'foo"bar',
+        '"unclosed',
+        "NEAR/",
+        "*",
+        "***",
+        '" "',
+    ],
+)
+def test_fact_retriever_fts_candidates_no_hits_for_fts5_syntax_text(
+    temp_store,
+    query,
+):
+    temp_store.add_fact("the cat sat on the mat", category="test")
+    retriever = FactRetriever(temp_store, hrr_weight=0.0)
+
+    assert retriever._fts_candidates(query, None, 0.3, 10) == []
+    assert retriever.search(query) == []
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("cat:", "the cat sat on the mat"),
+        ("issue:123", "see issue:123 for details"),
+        ("http://example.com", "visit http://example.com now"),
+        ("user's manual", "the user's manual"),
+        ("a AND", "a AND b are both listed"),
+    ],
+)
+def test_fact_retriever_fts_candidates_treats_query_as_literal_text(
+    temp_store,
+    query,
+    expected,
+):
+    for content in (
+        "the cat sat on the mat",
+        "see issue:123 for details",
+        "visit http://example.com now",
+        "the user's manual",
+        "a AND b are both listed",
+    ):
+        temp_store.add_fact(content, category="test")
+    retriever = FactRetriever(
+        temp_store,
+        fts_weight=1.0,
+        jaccard_weight=0.0,
+        hrr_weight=0.0,
+    )
+
+    candidates = retriever._fts_candidates(query, "test", 0.3, 10)
+    assert [result["content"] for result in candidates] == [expected]
+    assert candidates[0]["fts_rank"] == pytest.approx(1.0)
+
+    results = retriever.search(query, category="test")
+    assert [result["content"] for result in results] == [expected]
+    assert results[0]["score"] == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("query", ["", "   ", "\x00", "\x00\x00"])
+def test_fact_retriever_fts_candidates_empty_query_short_circuits(
+    temp_store,
+    query,
+):
+    temp_store.add_fact("the cat sat on the mat", category="test")
+    temp_store._conn.execute("DROP TABLE facts_fts")
+    retriever = FactRetriever(temp_store, hrr_weight=0.0)
+
+    assert retriever._fts_candidates(query, None, 0.3, 10) == []
+    assert retriever.search(query) == []
+
+
+def test_fact_retriever_fts_candidates_propagates_real_database_errors(temp_store):
+    temp_store.add_fact("the cat sat on the mat", category="test")
+    temp_store._conn.execute("DROP TABLE facts_fts")
+
+    with pytest.raises(sqlite3.OperationalError, match="facts_fts"):
+        FactRetriever(temp_store)._fts_candidates("cat", None, 0.3, 10)
+
+
 @pytest.mark.parametrize("hrr_dim", [0, -1, -1024])
 def test_memory_store_rejects_non_positive_hrr_dim(tmp_path, hrr_dim):
     """Reject before touching the DB, so no partial fact row can be committed."""


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: 072e3b44

### Description
Fix _fts_candidates in FactRetriever within src/ouroboros/memory.py to compile the query using _fts5_match_query(query) and return an empty list when no searchable tokens exist, preventing FTS5 syntax errors and silent candidate loss on queries containing colons, punctuation, or operators, and add unit test coverage in tests/test_memory.py.

### Evidence
FactRetriever._fts_candidates in src/ouroboros/memory.py passes the unescaped query string directly into 'facts_fts MATCH ?' instead of sanitizing it with _fts5_match_query(query). When queries contain colons (e.g., 'issue:123'), brackets (e.g., '[code]'), or FTS5 syntax, SQLite raises a sqlite3.OperationalError that is caught by the bare 'except Exception:' block and silently returns an empty candidate list, causing hybrid search to drop valid facts.

### Changes
- `src/ouroboros/memory.py`: Agent edit: src/ouroboros/memory.py
- `tests/test_memory.py`: Agent edit: tests/test_memory.py

### Test Results
- **Before**: 1000 passed, 0 failed, 0 errors (returncode=0), coverage=73.0%
- **After**: 1017 passed, 0 failed, 0 errors (returncode=0), coverage=73.0%

---
Generated autonomously by Ouroboros self-improvement engine.