### PR TITLE
[ouroboros] fix_bug: Fix bind, unbind, bundle, and snr_estimate in src/ouroboros/

### DIFF
--- a/src/ouroboros/holographic.py
+++ b/src/ouroboros/holographic.py
@@ -58,12 +58,16 @@ def encode_atom(word: str, dim: int = 1024) -> "np.ndarray":
 def bind(a: "np.ndarray", b: "np.ndarray") -> "np.ndarray":
     """Circular convolution -- element-wise phase addition."""
     _require_numpy()
+    if a.shape != b.shape:
+        raise ValueError(f"Vector shapes must match: {a.shape} vs {b.shape}")
     return (a + b) % _TWO_PI
 
 
 def unbind(memory: "np.ndarray", key: "np.ndarray") -> "np.ndarray":
     """Circular correlation -- element-wise phase subtraction."""
     _require_numpy()
+    if memory.shape != key.shape:
+        raise ValueError(f"Vector shapes must match: {memory.shape} vs {key.shape}")
     return (memory - key) % _TWO_PI
 
 
@@ -72,6 +76,10 @@ def bundle(*vectors: "np.ndarray") -> "np.ndarray":
     _require_numpy()
     if not vectors:
         raise ValueError("At least one vector must be provided to bundle")
+    target_shape = vectors[0].shape
+    for vector in vectors[1:]:
+        if vector.shape != target_shape:
+            raise ValueError(f"Vector shapes must match: {target_shape} vs {vector.shape}")
     complex_sum = np.sum([np.exp(1j * v) for v in vectors], axis=0)
     return np.angle(complex_sum) % _TWO_PI
 
@@ -127,6 +135,8 @@ def bytes_to_phases(data: bytes) -> "np.ndarray":
 
 def snr_estimate(dim: int, n_items: int) -> float:
     """Signal-to-noise ratio estimate for holographic storage."""
+    if dim <= 0:
+        raise ValueError(f"dim must be positive, got {dim}")
     if n_items <= 0:
         return float("inf")
     snr = math.sqrt(dim / n_items)

--- a/tests/test_holographic.py
+++ b/tests/test_holographic.py
@@ -64,6 +64,24 @@ def test_bind_unbind():
     retrieved_a = unbind(bound, b)
     assert np.allclose(retrieved_a, a)
 
+def test_bind_shape_mismatch():
+    a = encode_atom("key", dim=64)
+
+    with pytest.raises(ValueError, match="Vector shapes must match"):
+        bind(a, encode_atom("val", dim=128))
+
+    with pytest.raises(ValueError, match="Vector shapes must match"):
+        bind(a, np.zeros((64, 1), dtype=np.float64))
+
+def test_unbind_shape_mismatch():
+    memory = encode_atom("memory", dim=64)
+
+    with pytest.raises(ValueError, match="Vector shapes must match"):
+        unbind(memory, encode_atom("key", dim=128))
+
+    with pytest.raises(ValueError, match="Vector shapes must match"):
+        unbind(memory, np.zeros((64, 1), dtype=np.float64))
+
 def test_bundle():
     a = encode_atom("apple", dim=128)
     b = encode_atom("banana", dim=128)
@@ -84,6 +102,16 @@ def test_bundle():
 def test_bundle_empty():
     with pytest.raises(ValueError, match="At least one vector must be provided to bundle"):
         bundle()
+
+def test_bundle_shape_mismatch():
+    a = encode_atom("apple", dim=64)
+    b = encode_atom("banana", dim=64)
+
+    with pytest.raises(ValueError, match="Vector shapes must match"):
+        bundle(a, b, encode_atom("cherry", dim=128))
+
+    with pytest.raises(ValueError, match="Vector shapes must match"):
+        bundle(a, np.zeros((64, 1), dtype=np.float64))
 
 def test_similarity():
     a = encode_atom("cat", dim=64)
@@ -157,3 +185,8 @@ def test_snr_estimate(caplog):
         snr = snr_estimate(16, 8)
         assert snr < 2.0
         assert any("HRR storage near capacity" in record.message for record in caplog.records)
+
+@pytest.mark.parametrize("dim", [0, -1, -100])
+def test_snr_estimate_rejects_non_positive_dim(dim):
+    with pytest.raises(ValueError, match="dim must be positive"):
+        snr_estimate(dim, 0)


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: fix_bug
**Task ID**: eb49253c

### Description
Fix bind, unbind, bundle, and snr_estimate in src/ouroboros/holographic.py to validate vector shapes and dimensions, raising ValueError when vector shapes do not match or when dim is not positive in snr_estimate, and add unit test coverage in tests/test_holographic.py.

### Evidence
bind, unbind, and bundle in src/ouroboros/holographic.py do not validate matching input vector shapes (unlike similarity), allowing silent dimension broadcasting or unhandled numpy errors, and snr_estimate raises an unhandled math domain error when dim is non-positive instead of validating dim > 0.

### Changes
- `src/ouroboros/holographic.py`: Agent edit: src/ouroboros/holographic.py
- `tests/test_holographic.py`: Agent edit: tests/test_holographic.py

### Test Results
- **Before**: 1019 passed, 0 failed, 0 errors (returncode=0), coverage=73.0%
- **After**: 1025 passed, 0 failed, 0 errors (returncode=0), coverage=73.0%

---
Generated autonomously by Ouroboros self-improvement engine.