### PR TITLE
[ouroboros] add_feature: Add stopword filtering to encode_text in src/ouroboros/holog

### DIFF
--- a/src/ouroboros/holographic.py
+++ b/src/ouroboros/holographic.py
@@ -29,6 +29,30 @@ log = logging.getLogger(__name__)
 
 _TWO_PI = 2.0 * math.pi
 
+STOPWORDS: frozenset[str] = frozenset({
+    "a", "about", "above", "after", "again", "against", "all", "am", "an", "and",
+    "any", "are", "aren't", "as", "at", "be", "because", "been", "before",
+    "being", "below", "between", "both", "but", "by", "can", "can't", "cannot",
+    "could", "couldn't", "did", "didn't", "do", "does", "doesn't", "doing",
+    "don't", "down", "during", "each", "few", "for", "from", "further", "had",
+    "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd",
+    "he'll", "he's", "her", "here", "here's", "hers", "herself", "him",
+    "himself", "his", "how", "how's", "i", "i'd", "i'll", "i'm", "i've", "if",
+    "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me",
+    "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off",
+    "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves",
+    "out", "over", "own", "same", "shan't", "she", "she'd", "she'll", "she's",
+    "should", "shouldn't", "so", "some", "such", "than", "that", "that's", "the",
+    "their", "theirs", "them", "themselves", "then", "there", "there's", "these",
+    "they", "they'd", "they'll", "they're", "they've", "this", "those",
+    "through", "to", "too", "under", "until", "up", "very", "was", "wasn't",
+    "we", "we'd", "we'll", "we're", "we've", "were", "weren't", "what",
+    "what's", "when", "when's", "where", "where's", "which", "while", "who",
+    "who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't",
+    "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself",
+    "yourselves",
+})
+
 
 def _require_numpy() -> None:
     if not HAS_NUMPY:
@@ -98,7 +122,7 @@ def similarity(a: "np.ndarray", b: "np.ndarray") -> float:
 
 
 def encode_text(text: str, dim: int = 1024) -> "np.ndarray":
-    """Bag-of-words: bundle of atom vectors for each token."""
+    """Bag-of-words: bundle of atom vectors for non-stopword tokens."""
     _require_numpy()
     tokens = [
         token.strip(".,!?;:\"'()[]{}")
@@ -107,7 +131,9 @@ def encode_text(text: str, dim: int = 1024) -> "np.ndarray":
     tokens = [t for t in tokens if t]
     if not tokens:
         return encode_atom("__hrr_empty__", dim)
-    return bundle(*[encode_atom(token, dim) for token in tokens])
+    content_tokens = [token for token in tokens if token not in STOPWORDS]
+    active_tokens = content_tokens or tokens
+    return bundle(*[encode_atom(token, dim) for token in active_tokens])
 
 
 def encode_fact(content: str, entities: List[str], dim: int = 1024) -> "np.ndarray":

--- a/tests/test_holographic.py
+++ b/tests/test_holographic.py
@@ -151,6 +151,39 @@ def test_encode_text():
     v_ref = encode_atom("__hrr_empty__", dim=128)
     assert np.array_equal(v_empty, v_ref)
 
+def test_encode_text_filters_stopwords_before_bundling():
+    dim = 128
+    filtered = encode_text("The quick and the brown fox is here.", dim=dim)
+    expected = bundle(
+        encode_atom("quick", dim),
+        encode_atom("brown", dim),
+        encode_atom("fox", dim),
+    )
+
+    assert np.array_equal(filtered, expected)
+    assert np.array_equal(filtered, encode_text("quick brown fox", dim=dim))
+
+def test_encode_text_falls_back_to_all_tokens_when_all_stopwords():
+    dim = 128
+    encoded = encode_text("to be or not to be", dim=dim)
+    expected = bundle(
+        encode_atom("to", dim),
+        encode_atom("be", dim),
+        encode_atom("or", dim),
+        encode_atom("not", dim),
+        encode_atom("to", dim),
+        encode_atom("be", dim),
+    )
+
+    assert np.array_equal(encoded, expected)
+    assert not np.array_equal(encoded, encode_atom("__hrr_empty__", dim))
+
+def test_encode_text_filters_stopwords_after_case_and_punctuation_normalization():
+    assert np.array_equal(
+        encode_text("The, (AND) Is? QUICK!", dim=128),
+        encode_text("quick", dim=128),
+    )
+
 def test_encode_fact():
     content = "likes cheese"
     entities = ["Alice", "Bob"]
@@ -169,6 +202,18 @@ def test_encode_fact():
     
     unbound_entity = unbind(fact, role_entity)
     assert similarity(unbound_entity, alice_vec) > 0.1
+
+def test_encode_fact_uses_stopword_filtered_content():
+    dim = 128
+    fact = encode_fact("the latent vector stores the memory", ["Alice"], dim=dim)
+    role_content = encode_atom("__hrr_role_content__", dim)
+    role_entity = encode_atom("__hrr_role_entity__", dim)
+    expected = bundle(
+        bind(encode_text("latent vector stores memory", dim), role_content),
+        bind(encode_atom("alice", dim), role_entity),
+    )
+
+    assert np.array_equal(fact, expected)
 
 def test_serialization():
     v = encode_atom("serialize", dim=128)


### PR DESCRIPTION
## Autonomous Self-Improvement

**Type**: add_feature
**Task ID**: 615b54af

### Description
Add stopword filtering to encode_text in src/ouroboros/holographic.py using a defined set of common English stopwords to reduce token count before atom bundling in bundle(), falling back to all tokens if all words are stopwords, to improve holographic SNR during memory indexing and retrieval, and add unit tests in tests/test_holographic.py.

### Evidence
encode_text in src/ouroboros/holographic.py bundles atom phase vectors for all tokens including uninformative English stopwords ('the', 'is', 'at', 'and', etc.), which increases item count in bundle() superposition and directly degrades holographic SNR (scaling as sqrt(dim / n_items) in snr_estimate) and memory retrieval precision.

### Changes
- `src/ouroboros/holographic.py`: Agent edit: src/ouroboros/holographic.py
- `tests/test_holographic.py`: Agent edit: tests/test_holographic.py

### Test Results
- **Before**: 1025 passed, 0 failed, 0 errors (returncode=0), coverage=73.0%
- **After**: 1029 passed, 0 failed, 0 errors (returncode=0), coverage=73.0%

---
Generated autonomously by Ouroboros self-improvement engine.