### PR TITLE
fix(knowledge-base): treat a null summary timestamp as stale (#98)

### DIFF
--- a/src/ouroboros/knowledge_base.py
+++ b/src/ouroboros/knowledge_base.py
@@ -125,7 +125,9 @@ def get_summary(
         return ""
 
     cached = kb.get("summary_cache", "")
-    updated_at = kb.get("summary_updated_at", 0)
+    # The default only covers an absent key -- an explicit null, which is what
+    # an interrupted or hand-edited write leaves behind, still lands here.
+    updated_at = kb.get("summary_updated_at") or 0
     now = int(time.time())
 
     # Count entries added since last summary

--- a/tests/test_knowledge_base.py
+++ b/tests/test_knowledge_base.py
@@ -86,3 +86,16 @@ class TestKnowledgeBase:
         summary = get_summary(MagicMock(), kb, path=str(self.kb_file))
         assert summary == "recent summary"
         assert not mock_gen.called
+
+    @patch("ouroboros.llm.generate_kb_summary")
+    def test_get_summary_with_null_updated_at(self, mock_gen):
+        """A JSON null timestamp must degrade to a refresh, not a TypeError."""
+        mock_gen.return_value = "newly generated summary"
+        kb = {
+            "entries": [{"ts": 100, "insight": "i1"}],
+            "summary_cache": "old summary",
+            "summary_updated_at": None,  # what a JSON null deserializes to
+        }
+        summary = get_summary(MagicMock(), kb, path=str(self.kb_file))
+        assert summary == "newly generated summary"
+        assert mock_gen.called


### PR DESCRIPTION
Closes #98

`get_summary` read the cache timestamp with `kb.get("summary_updated_at", 0)`. The
default only fires when the key is absent, so a key present with an explicit JSON
`null` — what an interrupted or hand-edited write leaves behind — returned `None`
and blew up on the `now - updated_at` arithmetic with `TypeError: unsupported
operand type(s) for -: 'int' and 'NoneType'`. Changed to `kb.get("summary_updated_at") or 0`,
so a null timestamp reads as age-since-epoch and degrades to a summary refresh.

Regression test: `tests/test_knowledge_base.py::TestKnowledgeBase::test_get_summary_with_null_updated_at`
builds a KB with `"summary_updated_at": None` alongside a populated `summary_cache`,
and asserts `get_summary` returns the newly generated summary and that
`generate_kb_summary` was actually called — i.e. no exception, and the null is
treated as stale rather than as a fresh cache. Fails with `TypeError` before the fix.

## Dual review

Skipped for this change — the diff is a single-token fallback in one expression
plus its regression test, with no behavioral surface beyond the null case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmyQQBxUwKaEXXeFnV9b2D

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->