### PR TITLE
fix(llm): stop pick_oddities crashing on posts with a null title or content (#97)

### DIFF
--- a/src/ouroboros/llm.py
+++ b/src/ouroboros/llm.py
@@ -726,8 +726,11 @@ def pick_oddities(
     posts: list,
     model: str = DEFAULT_OPENAI_MODEL,
 ) -> Optional[str]:
-    posts_text = "\n\n".join([f"[{i}] {p.get('title')}: {p.get('content')[:200]}" for i, p in enumerate(posts[:20])])
     try:
+        posts_text = "\n\n".join([
+            f"[{i}] {p.get('title') or ''}: {(p.get('content') or '')[:200]}"
+            for i, p in enumerate(posts[:20])
+        ])
         resp = create_completion(
             client,
             model=model,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -18,6 +18,7 @@ from ouroboros.llm import (
     estimate_tokens,
     generate_comment,
     identify_improvements,
+    pick_oddities,
     load_openai_key,
     make_client,
     truncate_to_tokens,
@@ -185,6 +186,26 @@ def test_answer_question_returns_none_on_error():
     client = mock.MagicMock()
     client.chat.completions.create.side_effect = RuntimeError("fail")
     result = answer_question(client, "What is missing?")
+    assert result is None
+
+
+# -- pick_oddities tests --
+
+
+def test_pick_oddities_handles_posts_with_null_fields():
+    client = mock.MagicMock()
+    client.chat.completions.create.return_value = _mock_openai_response("Weird digest")
+    posts = [{"title": None, "content": None}, {}, {"title": "t", "content": "body"}]
+    result = pick_oddities(client, posts)
+    assert result == "Weird digest"
+    user_msg = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert user_msg == "[0] : \n\n[1] : \n\n[2] t: body"
+
+
+def test_pick_oddities_returns_none_on_error():
+    client = mock.MagicMock()
+    client.chat.completions.create.side_effect = Exception("API down")
+    result = pick_oddities(client, [{"title": "t", "content": "body"}])
     assert result is None
 
 


### PR DESCRIPTION
Closes #97

`pick_oddities` built its prompt string *before* entering its `try` block, and
interpolated `p.get('title')` / `p.get('content')[:200]` unguarded. A Moltbook post
with a null title or body therefore raised `TypeError` out of the function, past its
own `except` handler, and took the caller down with it. The prompt construction now
happens inside the `try`, and both fields are coerced with `or ''`, so a malformed
post yields an empty segment and any genuine failure returns `None` as the signature
promises.

Regression test: `tests/test_llm.py::test_pick_oddities_handles_posts_with_null_fields`
feeds a post with `title=None, content=None`, an entirely empty post, and one well-formed
post; it asserts the call succeeds and that the user message is exactly
`"[0] : \n\n[1] : \n\n[2] t: body"`. A companion test,
`test_pick_oddities_returns_none_on_error`, asserts the `except` path still returns `None`
when the API raises.

## Dual review

- **Codex (adversarial-review):** ran — no blocking findings. Verdict: the fix is
  correctly scoped; moving the comprehension inside `try` plus `or ''` coercion closes
  the `TypeError` escape without changing behaviour for well-formed posts.
- **agy (adversarial-review):** ran — no blocking findings. Verdict: change is minimal
  and behaviour-preserving; the regression test pins the exact prompt string, so a future
  refactor of the formatting cannot silently reintroduce the null dereference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->