### PR TITLE
fix(community): guard suggestion selection against an empty list (#96)

### DIFF
--- a/src/ouroboros/community_improvement.py
+++ b/src/ouroboros/community_improvement.py
@@ -352,7 +352,13 @@ def _step_analyze(
         return "fallback_no_actionable"
 
     # Select best suggestion by confidence
-    suggestions = analysis.get("suggestions", [])
+    suggestions = analysis.get("suggestions")
+    if not isinstance(suggestions, list) or not suggestions:
+        log.info("[community] Actionable flag set but no usable suggestions, falling back to LLM-only")
+        ci["status"] = "fallback"
+        ci["fallback_used"] = True
+        return "fallback_no_actionable"
+
     suggestions.sort(key=lambda s: s.get("confidence", 0), reverse=True)
     best = suggestions[0]
 

--- a/tests/test_community_improvement.py
+++ b/tests/test_community_improvement.py
@@ -267,6 +267,30 @@ def test_step_analyze_fallback_no_comments(mock_llm):
     assert state["community_improvement"]["fallback_used"] is True
 
 
+# -- test_step_analyze_fallback_actionable_without_suggestions --
+
+@patch("ouroboros.community_improvement.llm")
+def test_step_analyze_fallback_actionable_without_suggestions(mock_llm):
+    """has_actionable can be true while suggestions is empty, missing or null."""
+    comments = [{"id": "c1", "content": "fix the assertion", "author": {"name": "alice"}}]
+
+    for analysis in (
+        {"has_actionable": True, "suggestions": []},
+        {"has_actionable": True},
+        {"has_actionable": True, "suggestions": None},
+    ):
+        mock_llm.analyze_code_suggestions.return_value = analysis
+        ci = _make_ci_state(status="analyzing", comments_snapshot=comments)
+        state = _make_state(community_improvement=ci)
+        cfg = _make_cfg()
+
+        result = _step_analyze(MagicMock(), state, cfg)
+
+        assert result == "fallback_no_actionable"
+        assert state["community_improvement"]["status"] == "fallback"
+        assert state["community_improvement"]["fallback_used"] is True
+
+
 # -- test_step_implement_creates_pr_with_credit --
 
 @patch("ouroboros.community_improvement.get_repo_root")


### PR DESCRIPTION
Closes #96

`_step_analyze` treated the LLM's `has_actionable` flag as proof that `analysis["suggestions"]` held at least one entry, but the flag and the list are two independent claims by the model. With `suggestions` empty or missing, `suggestions[0]` raised `IndexError`; with an explicit `null`, the `.get` default never applied and `.sort` raised `AttributeError` one line earlier. Either way an inconsistent response crashed the community-improvement cycle.

The fix validates the payload instead of the flag: if `suggestions` is not a non-empty list, log and return `"fallback_no_actionable"` — the same fallback path that already sits directly above.

## Regression test

`test_step_analyze_fallback_actionable_without_suggestions` drives `_step_analyze` through all three malformed shapes (`{"suggestions": []}`, key missing, `{"suggestions": None}`) with `has_actionable` true, and asserts each returns `"fallback_no_actionable"` with `status == "fallback"` and `fallback_used is True`.

## Dual review

Codex ran: yes. agy ran: yes. Neither review returned a blocking finding against this change — the remediation list handed to this run was empty, so nothing required rework before landing.

Full suite green after rebasing onto current `main`: 1111 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmyQQBxUwKaEXXeFnV9b2D

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->