### PR TITLE
fix(improvement): grep_codebase reports "No matches found." instead of an error (#92)

### DIFF
--- a/src/ouroboros/improvement.py
+++ b/src/ouroboros/improvement.py
@@ -676,11 +676,16 @@ class ToolRunner:
             pattern = args.get("pattern", "")
             try:
                 import subprocess
-                out = subprocess.check_output(
+                # grep exits 1 when it simply found nothing; only >=2 is a real error.
+                proc = subprocess.run(
                     ["grep", "-r", "-n", "--include=*.py", pattern, str(self.repo_root / "src")],
-                    text=True, stderr=subprocess.STDOUT
+                    text=True, capture_output=True
                 )
-                return out or "No matches found."
+                if proc.returncode == 0:
+                    return proc.stdout or "No matches found."
+                if proc.returncode == 1:
+                    return "No matches found."
+                return f"Error running grep: {proc.stderr.strip()}"
             except Exception as e:
                 return f"Error running grep: {e}"
         elif name == "read_file_metadata":

--- a/tests/test_improvement.py
+++ b/tests/test_improvement.py
@@ -512,3 +512,42 @@ def test_a_trailing_space_does_not_hide_a_python_file():
         SafetyConfig(),
     )
     assert any("pickle" in v for v in violations), violations
+
+
+def _tool_runner_repo(tmp_path):
+    """A repo_root whose src/ holds one grep-able module."""
+    src_dir = tmp_path / "src" / "ouroboros"
+    src_dir.mkdir(parents=True)
+    (src_dir / "sample.py").write_text("def findable_symbol():\n    return 1\n")
+    return tmp_path
+
+
+def test_grep_codebase_reports_no_matches_instead_of_an_error(tmp_path):
+    """grep exits 1 when it found nothing -- that is an answer, not breakage."""
+    from ouroboros.improvement import ToolRunner
+
+    out = ToolRunner(_tool_runner_repo(tmp_path)).execute(
+        "grep_codebase", {"pattern": "ZZZ_NO_MATCH_ZZZ"}
+    )
+    assert out == "No matches found."
+
+
+def test_grep_codebase_returns_the_matching_lines(tmp_path):
+    from ouroboros.improvement import ToolRunner
+
+    out = ToolRunner(_tool_runner_repo(tmp_path)).execute(
+        "grep_codebase", {"pattern": "findable_symbol"}
+    )
+    assert "sample.py" in out and "findable_symbol" in out
+
+
+def test_grep_codebase_still_reports_a_real_failure(tmp_path):
+    """Exit >=2 -- here an unbalanced bracket -- stays an error, with grep's own text."""
+    from ouroboros.improvement import ToolRunner
+
+    out = ToolRunner(_tool_runner_repo(tmp_path)).execute(
+        "grep_codebase", {"pattern": "["}
+    )
+    assert out.startswith("Error running grep:")
+    assert out != "Error running grep:"
+    assert "No matches found." not in out


### PR DESCRIPTION
Closes #92

`ToolRunner.grep_codebase` used `subprocess.check_output`, which raises on any
non-zero exit. grep exits 1 when it simply found nothing, so an ordinary
"no matches" search came back to the agent as a `CalledProcessError` string —
indistinguishable from a real tool failure. It now uses `subprocess.run` and
branches on the exit code: 0 returns the matching lines, 1 returns
`"No matches found."`, and >=2 returns `"Error running grep: <stderr>"`.

## Regression test

Three tests in `tests/test_improvement.py`, each against a temp repo containing one
grep-able module:

- `test_grep_codebase_reports_no_matches_instead_of_an_error` — a pattern that
  cannot match returns exactly `"No matches found."` (fails before the change).
- `test_grep_codebase_returns_the_matching_lines` — a matching pattern still
  returns the file name and the symbol.
- `test_grep_codebase_still_reports_a_real_failure` — an unbalanced `[` (grep
  exit 2) still returns a non-empty `"Error running grep: ..."` and is never
  mistaken for the no-match case.

Full suite: 1116 passed.

## Dual review

- **Codex** (adversarial review): ran, no blocking findings. Verdict: the exit-code
  branch is the correct fix and the 0/1/>=2 split is exhaustive for grep.
- **agy / Antigravity** (adversarial review): ran, no blocking findings. Verdict:
  behaviour change is contained to the no-match path; real errors still surface
  with grep's own stderr text.

Nothing was left unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->