### PR TITLE
fix(improvement): stop revert from deleting a pre-existing empty file (#91)

### DIFF
--- a/src/ouroboros/improvement.py
+++ b/src/ouroboros/improvement.py
@@ -59,7 +59,8 @@ class CodeChange:
     # Whether the file was already on disk before the change was applied.
     # An empty original_content cannot tell a newly created file from an
     # existing empty one, so apply_changes stamps this from the filesystem and
-    # revert_changes trusts it instead of guessing (#91). None = never applied.
+    # revert_changes trusts it instead of guessing (#91). None = never went
+    # through apply_changes, so revert_changes leaves that file alone.
     existed_before: Optional[bool] = None
 
 
@@ -356,16 +357,24 @@ def apply_changes(
 
 
 def revert_changes(changes: List[CodeChange], repo_root: Path) -> None:
-    """Revert changes by restoring original file contents."""
-    for change in changes:
+    """Undo what ``apply_changes`` wrote, in reverse order of application.
+
+    Reverse order because two entries can name the same file (a create
+    followed by an edit of it). Applied forwards, the create is undone first
+    -- the file is unlinked -- and then the edit resurrects it, leaving a
+    stray file behind and the worktree dirty, which blocks every later cycle.
+    """
+    for change in reversed(changes):
+        # An existing empty file carries original_content == "" just like a
+        # brand new one, so emptiness cannot say whether the file is ours to
+        # delete (#91). Only the filesystem can, and apply_changes recorded
+        # what it saw there. None means this change never reached
+        # apply_changes -- nothing was written, so there is nothing to undo,
+        # and touching the file would clobber content we never wrote.
+        if change.existed_before is None:
+            continue
         full_path = repo_root / change.file_path
-        # An existing empty file also carries original_content == "", so
-        # emptiness alone is not "the file is ours to delete" -- use what
-        # apply_changes saw on disk, and only guess when it never ran.
-        existed = change.existed_before
-        if existed is None:
-            existed = bool(change.original_content)
-        if existed:
+        if change.existed_before:
             full_path.write_text(change.original_content, encoding="utf-8")
         elif full_path.exists():
             # File was newly created, remove it

--- a/src/ouroboros/improvement.py
+++ b/src/ouroboros/improvement.py
@@ -56,6 +56,11 @@ class CodeChange:
     original_content: str
     new_content: str
     description: str
+    # Whether the file was already on disk before the change was applied.
+    # An empty original_content cannot tell a newly created file from an
+    # existing empty one, so apply_changes stamps this from the filesystem and
+    # revert_changes trusts it instead of guessing (#91). None = never applied.
+    existed_before: Optional[bool] = None
 
 
 @dataclass
@@ -343,6 +348,9 @@ def apply_changes(
             raise PermissionError(f"Cannot modify forbidden file: {change.file_path}")
 
         full_path = _resolved_inside(repo_root, change.file_path, config)
+        # Ground truth for the revert: taken from the filesystem here because
+        # this is the last moment the pre-change tree still exists.
+        change.existed_before = full_path.exists()
         full_path.parent.mkdir(parents=True, exist_ok=True)
         full_path.write_text(change.new_content, encoding="utf-8")
 
@@ -351,7 +359,13 @@ def revert_changes(changes: List[CodeChange], repo_root: Path) -> None:
     """Revert changes by restoring original file contents."""
     for change in changes:
         full_path = repo_root / change.file_path
-        if change.original_content:
+        # An existing empty file also carries original_content == "", so
+        # emptiness alone is not "the file is ours to delete" -- use what
+        # apply_changes saw on disk, and only guess when it never ran.
+        existed = change.existed_before
+        if existed is None:
+            existed = bool(change.original_content)
+        if existed:
             full_path.write_text(change.original_content, encoding="utf-8")
         elif full_path.exists():
             # File was newly created, remove it

--- a/tests/test_improvement.py
+++ b/tests/test_improvement.py
@@ -201,6 +201,27 @@ def test_revert_new_file(tmp_path):
     assert not target.exists()  # empty original means file was new, so remove it
 
 
+def test_revert_keeps_an_existing_empty_file(tmp_path):
+    """A tracked-but-empty file carries the same original_content ("") as a
+    brand new one, so revert must not infer "newly created" from emptiness and
+    unlink it (#91)."""
+    src_dir = tmp_path / "src" / "ouroboros"
+    src_dir.mkdir(parents=True)
+    target = src_dir / "empty.py"
+    target.write_text("")
+
+    changes = [
+        CodeChange("src/ouroboros/empty.py", "", "VALUE = 1\n", "fill it in"),
+    ]
+    apply_changes(changes, tmp_path)
+    assert target.read_text() == "VALUE = 1\n"
+
+    revert_changes(changes, tmp_path)
+
+    assert target.exists(), "revert deleted a file that existed before the change"
+    assert target.read_text() == ""
+
+
 def test_build_failed_attempts_context_uses_outcome_only():
     history = [
         EvaluationRecord(

--- a/tests/test_improvement.py
+++ b/tests/test_improvement.py
@@ -181,7 +181,10 @@ def test_revert_changes(tmp_path):
     target.write_text("modified")
 
     changes = [
-        CodeChange("src/ouroboros/foo.py", "original", "modified", "test"),
+        CodeChange(
+            "src/ouroboros/foo.py", "original", "modified", "test",
+            existed_before=True,
+        ),
     ]
     revert_changes(changes, tmp_path)
 
@@ -195,10 +198,13 @@ def test_revert_new_file(tmp_path):
     target.write_text("new content")
 
     changes = [
-        CodeChange("src/ouroboros/new_file.py", "", "new content", "new file"),
+        CodeChange(
+            "src/ouroboros/new_file.py", "", "new content", "new file",
+            existed_before=False,
+        ),
     ]
     revert_changes(changes, tmp_path)
-    assert not target.exists()  # empty original means file was new, so remove it
+    assert not target.exists()  # was not on disk before, so remove it
 
 
 def test_revert_keeps_an_existing_empty_file(tmp_path):
@@ -220,6 +226,45 @@ def test_revert_keeps_an_existing_empty_file(tmp_path):
 
     assert target.exists(), "revert deleted a file that existed before the change"
     assert target.read_text() == ""
+
+
+def test_revert_removes_a_new_file_touched_by_two_changes(tmp_path):
+    """Two entries can name the same new file (create, then edit it). The
+    second one is applied to a file the first just created, so it records
+    existed_before=True. Reverting forwards would unlink it for the first
+    entry and then write it back for the second, leaving a stray file and a
+    dirty worktree that blocks every later cycle."""
+    src_dir = tmp_path / "src" / "ouroboros"
+    src_dir.mkdir(parents=True)
+    target = src_dir / "brand_new.py"
+
+    changes = [
+        CodeChange("src/ouroboros/brand_new.py", "", "A = 1\n", "create"),
+        CodeChange("src/ouroboros/brand_new.py", "", "A = 2\n", "edit it"),
+    ]
+    apply_changes(changes, tmp_path)
+    assert [c.existed_before for c in changes] == [False, True]
+
+    revert_changes(changes, tmp_path)
+
+    assert not target.exists(), "revert left behind a file that did not exist before"
+
+
+def test_revert_skips_changes_that_were_never_applied(tmp_path):
+    """apply_changes stamps existed_before; a change that never reached it
+    was never written, so revert must not touch that file. Guessing from an
+    empty original_content would unlink a file already on disk."""
+    src_dir = tmp_path / "src" / "ouroboros"
+    src_dir.mkdir(parents=True)
+    untouched = src_dir / "untouched.py"
+    untouched.write_text("KEEP = 1\n")
+
+    revert_changes(
+        [CodeChange("src/ouroboros/untouched.py", "", "NEW = 1\n", "never applied")],
+        tmp_path,
+    )
+
+    assert untouched.read_text() == "KEEP = 1\n"
 
 
 def test_build_failed_attempts_context_uses_outcome_only():


### PR DESCRIPTION
Closes #91

`original_content` is built as `file_contents.get(path, "")`, so a newly created file and an existing empty file both carry `""`. `revert_changes` tested that string for truthiness and unlinked anything empty, so the rollback path -- the thing that restores the tree after a failed improvement -- silently deleted tracked empty files such as `tests/__init__.py`.

`CodeChange` now carries `existed_before`, stamped by `apply_changes` from the filesystem at the last moment the pre-change tree still exists, and `revert_changes` trusts that flag. It also undoes in reverse order and skips changes that never reached `apply_changes` (see Dual review).

### Regression tests

- `test_revert_keeps_an_existing_empty_file` -- writes an empty file, applies a change to it through `apply_changes`, reverts, asserts the file still exists and is empty again.
- `test_revert_removes_a_new_file_touched_by_two_changes` -- two entries naming the same new file (create, then edit). Asserts `apply_changes` records `[False, True]` and that after the revert no file is left behind.
- `test_revert_skips_changes_that_were_never_applied` -- an unstamped change (`existed_before is None`) must leave an existing file untouched.

All three fail on the commit before their fix. Full suite: 1121 passed.

## Dual review

**Codex** -- blocking: "Duplicate change entries targeting the same absent file record `existed_before` as `[False, True]`; the forward-order revert deletes the file for entry 1 and then recreates it (empty) from entry 2, leaving the repo dirty and blocking later cycles." Reproduced; `_validate_changes` does not reject duplicate paths. Recommended rejecting duplicate resolved targets or snapshotting existence once per target, plus a two-entry regression test.

**agy** -- blocking: "The new `existed is None -> bool(change.original_content)` fallback keeps the #91 guess for changes that were never applied (apply_changes aborted midway): an unapplied new-file change with empty original_content makes revert unlink a file that already existed on disk, and an unapplied edit with non-empty original_content overwrites an untouched file." Recommended skipping changes whose `existed_before` is None instead of guessing.

**agy** -- blocking: "`revert_changes` iterates forwards, so when multiple `CodeChange` entries hit the same file (create then modify) it deletes on the first and resurrects it on the second." Recommended iterating `reversed(changes)`.

**Remediation** (commit 2): `revert_changes` now iterates `reversed(changes)` and returns early on `existed_before is None`.

- The two same-file reports are one defect with two proposed remedies. `reversed(changes)` is the smaller of them -- undo in the reverse order of application -- and it fixes Codex's exact scenario too: the edit entry is unwound first (writing the file back), then the create entry unlinks it, so nothing is left behind. No change to `_validate_changes`, no per-target existence map.
- Dropping the `None` fallback is strictly better on the mixed case that motivates it: if `apply_changes` raises partway, entries 1..k are stamped and unwound correctly while k+1..n were never written and are now correctly left alone. (No caller reverts after a failed `apply_changes` today -- both call sites return without reverting -- so this was latent, not live.) The two direct-call revert tests now pass `existed_before` explicitly to say which case they cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->