### PR TITLE
fix(policies): make config the single source of the immutable-file list

### DIFF
--- a/src/ouroboros/config.py
+++ b/src/ouroboros/config.py
@@ -69,6 +69,10 @@ class SafetyConfig:
         "tests/",
         "docs/wiki/",
     )
+    # The single source of truth for the immutable-file list. Both the
+    # enforcement gate (improvement._is_path_allowed) and the version metrics
+    # reports from (policies.validate_modification_scope) read this one tuple,
+    # so they cannot disagree about what is immutable (#112).
     forbidden_modification_paths: Tuple[str, ...] = (
         "config.py",
         "improvement.py",

--- a/src/ouroboros/improvement.py
+++ b/src/ouroboros/improvement.py
@@ -76,16 +76,6 @@ class ImprovementResult:
     total_usage: Dict[str, int] = field(default_factory=lambda: {"prompt_tokens": 0, "completion_tokens": 0})
 
 
-# Hardcoded immutable files that can never be modified
-IMMUTABLE_FILES = frozenset({
-    "config.py",
-    "improvement.py",
-    "git_ops.py",
-    "evaluation.py",
-    "policies.py",
-})
-
-
 PYTHON_SUFFIXES = frozenset({".py", ".pyi", ".pyw"})
 
 
@@ -112,11 +102,14 @@ def _is_path_allowed(file_path: str, config: SafetyConfig) -> bool:
     Both halves come from policies, so this gate and
     validate_modification_scope cannot drift apart -- they did, and the raw
     prefix compare here accepted "src/../../etc/passwd" as being under "src/".
+
+    The immutable-file list comes from config for the same reason. This gate
+    used to carry its own hardcoded copy, which validate_modification_scope --
+    the version metrics reports from -- could not see, so a change to either
+    list would have made enforcement and metrics disagree (#112).
     """
     from .policies import is_forbidden_modification_path, is_within_allowed_paths
 
-    if Path(file_path).name in IMMUTABLE_FILES:
-        return False
     if is_forbidden_modification_path(file_path, config.forbidden_modification_paths):
         return False
 

--- a/tests/test_improvement.py
+++ b/tests/test_improvement.py
@@ -11,7 +11,6 @@ from ouroboros.improvement import (
     ImprovementTask,
     CodeChange,
     ImprovementResult,
-    IMMUTABLE_FILES,
     _build_failed_attempts_context,
     _build_success_rate_context,
     _is_path_allowed,
@@ -28,11 +27,13 @@ from ouroboros.test_runner import RunnerOutcome
 
 
 def test_immutable_files():
-    assert "config.py" in IMMUTABLE_FILES
-    assert "improvement.py" in IMMUTABLE_FILES
-    assert "git_ops.py" in IMMUTABLE_FILES
-    assert "evaluation.py" in IMMUTABLE_FILES
-    assert "policies.py" in IMMUTABLE_FILES
+    """The shipped config is the immutable-file list; the enforcement gate
+    reads it rather than a second hardcoded copy (#112)."""
+    config = SafetyConfig()
+    for name in ("config.py", "improvement.py", "git_ops.py", "evaluation.py",
+                 "policies.py"):
+        assert name in config.forbidden_modification_paths
+        assert _is_path_allowed(f"src/ouroboros/{name}", config) is False
 
 
 def test_is_path_allowed():

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -591,14 +591,66 @@ def test_a_null_byte_is_not_a_path():
     assert is_safe_relative_path("src/ouroboros/x.py\x00.md") is False
 
 
-def test_the_two_immutable_lists_cannot_drift_apart():
-    """improvement.IMMUTABLE_FILES and SafetyConfig.forbidden_modification_paths
-    are maintained by hand and consulted by different gates. They are equal
-    today; this fails the moment they are not."""
-    from ouroboros.config import SafetyConfig
-    from ouroboros.improvement import IMMUTABLE_FILES
+def _rejected_by_enforcement(paths, config):
+    from ouroboros.improvement import _is_path_allowed
 
-    assert set(IMMUTABLE_FILES) == set(SafetyConfig().forbidden_modification_paths)
+    return {p for p in paths if not _is_path_allowed(p, config)}
+
+
+def _rejected_by_metrics_path(paths, config):
+    return {p for p in paths if validate_modification_scope([p], config)}
+
+
+# Every forbidden entry, plus a near-miss for each, plus an allowed file.
+_SCOPE_FIXTURE = (
+    "src/ouroboros/config.py",
+    "src/ouroboros/improvement.py",
+    "src/ouroboros/git_ops.py",
+    "src/ouroboros/evaluation.py",
+    "src/ouroboros/policies.py",
+    "src/ouroboros/policies.pyx",
+    "tests/config.py",
+    "src/ab/thing.py",
+    "src/ouroboros/llm.py",
+    "README.md",
+    "src/../../etc/passwd",
+)
+
+
+def test_enforcement_and_the_metrics_path_reject_the_same_files():
+    """_is_path_allowed is the gate; validate_modification_scope is what
+    metrics reports from. A file one rejects and the other accepts is a
+    metric that contradicts what the agent was actually allowed to do."""
+    config = SafetyConfig()
+    assert (
+        _rejected_by_enforcement(_SCOPE_FIXTURE, config)
+        == _rejected_by_metrics_path(_SCOPE_FIXTURE, config)
+    )
+    # tests/config.py is forbidden by basename, so both must reject it; the
+    # near-misses next to it must be accepted by both.
+    assert "tests/config.py" in _rejected_by_enforcement(_SCOPE_FIXTURE, config)
+    assert "src/ouroboros/llm.py" not in _rejected_by_enforcement(
+        _SCOPE_FIXTURE, config
+    )
+
+
+def test_the_immutable_list_has_a_single_source():
+    """The two gates read one list, so changing it moves both. With a second
+    hardcoded copy in improvement.py, a config that no longer forbids
+    improvement.py would still be enforced against while metrics reported the
+    change as in scope (#112)."""
+    config = SafetyConfig(forbidden_modification_paths=("secret.py",))
+    paths = (
+        "src/ouroboros/improvement.py",
+        "src/ouroboros/policies.py",
+        "src/ouroboros/secret.py",
+        "src/ouroboros/llm.py",
+    )
+    assert (
+        _rejected_by_enforcement(paths, config)
+        == _rejected_by_metrics_path(paths, config)
+        == {"src/ouroboros/secret.py"}
+    )
 
 
 # -- the filesystem answers what a lexical check cannot ----------------------


### PR DESCRIPTION
## Problem

The list of files the agent may never modify was written down twice, in two modules, in two formats:

- `src/ouroboros/improvement.py:80` — `IMMUTABLE_FILES = frozenset({...})`
- `src/ouroboros/config.py:72` — `SafetyConfig.forbidden_modification_paths = (...)`

`_is_path_allowed` consulted both, so enforcement was the union of the two. `policies.validate_modification_scope` consulted only the config half and did not know `IMMUTABLE_FILES` existed — and that is the function whose result is serialized into metrics (`metrics.py:107`).

No behavioural difference today: the two lists are identical, and `forbidden_modification_paths` is not reachable from `agent.json`. The failure lands the moment either list is edited — metrics would report a change as in scope that enforcement rejected, and #90 ("does self-improvement actually compound?") is answered from those metrics.

## Fix

Delete `IMMUTABLE_FILES` and let `config.forbidden_modification_paths` be the one list, as the issue suggests.

`is_forbidden_modification_path` already matches a bare filename by basename anywhere in the tree — the same semantics the frozenset provided, plus the case-folding and NFC normalisation that the raw `Path(file_path).name in IMMUTABLE_FILES` check lacked. With the two lists equal this changes no behaviour. No call site in `src/` overrides `forbidden_modification_paths` (checked: `moltbook.py:1635`, `improvement_runner.py:282`, and every other `SafetyConfig(...)` construction leave it at the default).

Also adds a short comment on the config field marking it as the single source.

## Test evidence

- **`tests/test_policies.py::test_the_immutable_list_has_a_single_source`** is the test that fails before and passes after. Under a config that forbids something else (`forbidden_modification_paths=("secret.py",)`), enforcement and the metrics path must reject the same set. On the old code it fails:

  ```
  E       AssertionError: assert {'src/ourobor...os/secret.py'} == {'src/ouroboros/secret.py'}
  E         Extra items in the left set:
  E         'src/ouroboros/policies.py'
  E         'src/ouroboros/improvement.py'
  ```

  That is exactly the drift the issue describes: enforcement blocks two files the metrics path reports as in scope.

- `tests/test_policies.py::test_enforcement_and_the_metrics_path_reject_the_same_files` is the fixture the issue asked for — every forbidden entry, plus a near-miss for each (`policies.pyx`, `tests/config.py`, `src/ab/...`), plus an allowed file and an escaping path — asserting the two rejection sets are equal.

- `test_the_two_immutable_lists_cannot_drift_apart` is removed; it can no longer be written now that there is only one list. `tests/test_improvement.py::test_immutable_files` now asserts the shipped config blocks each of the five files through `_is_path_allowed`.

Full suite on this branch:

```
1122 passed in 7.12s
```

Baseline on `fd49d8b5` (this branch's merge-base) is `1121 passed` — net +1 (two tests added, one removed).

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJo9JBknnTZfzmpKUBU9kM
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->