### PR TITLE
fix(moltbook): survive a null author in the three comment paths (#113)

### DIFF
--- a/src/ouroboros/llm.py
+++ b/src/ouroboros/llm.py
@@ -550,6 +550,25 @@ def generate_question_post(
         return None
 
 
+def _format_comments(comments: list) -> str:
+    """Render comments for a prompt, tolerating a malformed author.
+
+    `c.get("author", {})` only falls back when the key is absent, so an
+    explicit JSON null -- or a bare string author -- raised AttributeError
+    and killed the analysis of an otherwise usable comment set. An author
+    that carries no name renders as "unknown" instead.
+    """
+    lines = []
+    for c in comments:
+        author = c.get("author")
+        if isinstance(author, dict):
+            author = author.get("name")
+        if not isinstance(author, str) or not author:
+            author = "unknown"
+        lines.append(f"Comment by {author}: {c.get('content')}")
+    return "\n\n".join(lines)
+
+
 def analyze_code_suggestions(
     client: Any,
     problem: str,
@@ -558,8 +577,8 @@ def analyze_code_suggestions(
     model: str = DEFAULT_OPENAI_MODEL,
 ) -> Optional[dict]:
     code_block = "\n\n".join(f"### {path}\n```python\n{content}\n```" for path, content in code_context.items())
-    comments_text = "\n\n".join(f"Comment by {c.get('author', {}).get('name')}: {c.get('content')}" for c in comments)
     try:
+        comments_text = _format_comments(comments)
         resp = create_completion(
             client,
             model=model,
@@ -609,8 +628,8 @@ def analyze_comments_for_upgrades(
     comments: list,
     model: str = DEFAULT_OPENAI_MODEL,
 ) -> Optional[dict]:
-    comments_text = "\n\n".join([f"Comment by {c.get('author', {}).get('name')}: {c.get('content')}" for c in comments])
     try:
+        comments_text = _format_comments(comments)
         resp = create_completion(
             client,
             model=model,

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -169,11 +169,26 @@ def get_post_comments(api_key: str, post_id: str) -> Dict[str, Any]:
     return _request("GET", f"/posts/{post_id}/comments", api_key)
 
 
+def _author_name(record: Dict[str, Any]) -> Optional[str]:
+    """Author name of a feed record, or None when the author is malformed.
+
+    `record.get("author", {})` only falls back when the key is absent: an
+    explicit JSON null hands back None, and a bare string author is not a
+    mapping either. Both used to raise AttributeError here and abort the
+    whole poll over one bad record.
+    """
+    author = record.get("author")
+    if not isinstance(author, dict):
+        return None
+    name = author.get("name")
+    return name if isinstance(name, str) else None
+
+
 def get_my_posts(api_key: str, agent_name: str, limit: int = 10) -> List[Dict[str, Any]]:
     """Fetch posts authored by this agent."""
     feed = get_feed(api_key, sort="new", limit=50)
     posts = feed.get("posts", [])
-    return [p for p in posts if p.get("author", {}).get("name") == agent_name][:limit]
+    return [p for p in posts if _author_name(p) == agent_name][:limit]
 
 
 @dataclass

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -9,6 +9,8 @@ from ouroboros.llm import (
     MAX_CODEBASE_SUMMARY_TOKENS,
     MAX_HISTORY_TOKENS,
     MAX_TEST_OUTPUT_TOKENS,
+    analyze_code_suggestions,
+    analyze_comments_for_upgrades,
     answer_question,
     create_completion,
     fit_messages_to_budget,
@@ -483,3 +485,42 @@ def test_cli_agent_prompt_is_bounded():
     prompt = _build_agent_prompt(task, "P" * 500_000, config, model="gemma4")
 
     assert estimate_tokens(prompt) <= model_input_budget("gemma4")
+
+
+# -- comment rendering with a malformed author (#113) -----------------------
+
+MALFORMED_AUTHORS = [
+    ({"content": "x"}, "Comment by unknown: x"),                    # key absent
+    ({"author": None, "content": "x"}, "Comment by unknown: x"),    # explicit null
+    ({"author": {}, "content": "x"}, "Comment by unknown: x"),      # no name
+    ({"author": 42, "content": "x"}, "Comment by unknown: x"),      # not an object
+    ({"author": "bob", "content": "x"}, "Comment by bob: x"),       # bare name
+    ({"author": {"name": "bob"}, "content": "x"}, "Comment by bob: x"),
+]
+
+
+@pytest.mark.parametrize("comment,expected", MALFORMED_AUTHORS)
+def test_analyze_code_suggestions_renders_a_malformed_author(comment, expected):
+    """A null author raised AttributeError before the try, so the caller's
+    error boundary never ran and community_improvement stayed in 'analyzing'
+    -- a status the 24h stale-state sweep does not clear."""
+    client = mock.MagicMock()
+    client.chat.completions.create.return_value = _mock_openai_response('{"has_actionable": false}')
+
+    result = analyze_code_suggestions(client, "problem", {}, [comment])
+
+    assert result == {"has_actionable": False}
+    user_msg = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert expected in user_msg
+
+
+@pytest.mark.parametrize("comment,expected", MALFORMED_AUTHORS)
+def test_analyze_comments_for_upgrades_renders_a_malformed_author(comment, expected):
+    client = mock.MagicMock()
+    client.chat.completions.create.return_value = _mock_openai_response('{"has_upgrade": false}')
+
+    result = analyze_comments_for_upgrades(client, "title", "post", [comment])
+
+    assert result == {"has_upgrade": False}
+    user_msg = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert expected in user_msg

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -14,6 +14,7 @@ from ouroboros.moltbook import (
     MoltbookError,
     RunnerConfig,
     _trim_self_question_log,
+    get_my_posts,
     load_credentials,
     load_runner_config,
     load_state,
@@ -977,3 +978,24 @@ def test_the_daily_improvement_cap_defaults_to_the_safety_default():
     from ouroboros.config import SafetyConfig
 
     assert RunnerConfig().max_improvements_per_day == SafetyConfig().max_improvements_per_day
+
+
+# -- get_my_posts with a malformed author (#113) --
+
+
+@pytest.mark.parametrize("bad", [
+    {"id": "1"},                      # author key absent
+    {"id": "1", "author": None},      # explicit JSON null
+    {"id": "1", "author": "agent"},   # not an object
+    {"id": "1", "author": 42},
+])
+def test_get_my_posts_skips_a_record_with_a_malformed_author(bad):
+    """A null author aborted the whole poll instead of skipping one record.
+
+    `.get("author", {})` only falls back when the key is absent, so an
+    explicit null raised AttributeError -- and the caller never advanced
+    last_comment_check, so every later cycle re-read the same bad feed.
+    """
+    mine = {"id": "2", "author": {"name": "agent"}}
+    with mock.patch("ouroboros.moltbook.get_feed", return_value={"posts": [bad, mine]}):
+        assert get_my_posts("key", "agent") == [mine]


### PR DESCRIPTION
## Problem

`.get("author", {})` only falls back when the key is **absent**. An external Moltbook payload carrying an explicit JSON `null` hands back `None`, so the nested `.get("name")` raised `AttributeError`; a bare string author broke the same way. Three paths were affected, all reproducible on `fd49d8b5`:

- `src/ouroboros/moltbook.py:176` (`get_my_posts`) — aborted the whole comment-based upgrade poll on one bad feed record. The caller catches the exception but never advances `last_comment_check`, so every later cycle re-read the same bad feed and failed again.
- `src/ouroboros/llm.py:561` (`analyze_code_suggestions`) — built `comments_text` *before* its own `try`, so the documented `None` fallback never ran. `_step_analyze` has already set `community_improvement.status` to `"analyzing"`, and the 24h stale-state sweep only clears `identified`/`posted`/`waiting` — so the state machine could stay wedged there indefinitely.
- `src/ouroboros/llm.py:612` (`analyze_comments_for_upgrades`) — lost analysis of otherwise valid comments in the direct comment-upgrade path.

## Fix

- `moltbook._author_name()` returns the author name only when `author` is a mapping, and `get_my_posts` skips records where it is not. Skipping rather than coercing is deliberate: matching a malformed record could attribute someone else's post to the agent and trigger a comment-based upgrade on it.
- `llm._format_comments()` renders an unusable author as `"unknown"` (a bare string author is taken as the name), and both LLM helpers now build the comment text **inside** their `try`. `analyze_code_suggestions` returning `None` routes `_step_analyze` to `"fallback"`, so a malformed record can no longer leave the community state machine stuck in `"analyzing"`.

No other behaviour changed; the stale-state sweep and the state machine itself are untouched.

## Test evidence

New regression tests (16 cases) covering an absent, `null`, non-object, and bare-string author on each of the three paths:

- `tests/test_moltbook.py::test_get_my_posts_skips_a_record_with_a_malformed_author`
- `tests/test_llm.py::test_analyze_code_suggestions_renders_a_malformed_author`
- `tests/test_llm.py::test_analyze_comments_for_upgrades_renders_a_malformed_author`

With the source fix stashed, 13 of the 16 fail with `AttributeError: 'NoneType' object has no attribute 'get'` (and the `int`/`str` variants); with it applied all 16 pass.

Full suite on this branch:

```
1137 passed in 7.06s
```

Baseline on `origin/main` (`fd49d8b5`) in the same worktree: `1121 passed` — same tests, plus the 16 new ones.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJo9JBknnTZfzmpKUBU9kM

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->