### PR TITLE
fix(config): warn about agent.json keys that are not settings (#111)

### DIFF
--- a/src/ouroboros/config_schema.py
+++ b/src/ouroboros/config_schema.py
@@ -166,6 +166,21 @@ def settable_error(key: str) -> Optional[str]:
     return None
 
 
+def unknown_key_error(key: str) -> Optional[str]:
+    """Return an error if this key is not a setting at all.
+
+    Split out of `validate` for the caller that holds a whole config file: its
+    values are already whatever the file said, so the key is the only question,
+    and the answer has to read the same as `config set` gives.
+    """
+    types = field_types()
+    if key in types:
+        return None
+    suggestion = _closest(key, types)
+    hint = f"; did you mean {suggestion}?" if suggestion else ""
+    return f"unknown setting {key!r}{hint}"
+
+
 def validate(key: str, value: Any) -> Optional[str]:
     """Return an error message if key/value is not a valid config setting.
 
@@ -174,9 +189,7 @@ def validate(key: str, value: Any) -> Optional[str]:
     """
     types = field_types()
     if key not in types:
-        suggestion = _closest(key, types)
-        hint = f"; did you mean {suggestion}?" if suggestion else ""
-        return f"unknown setting {key!r}{hint}"
+        return unknown_key_error(key)
 
     declared = types[key]
 

--- a/src/ouroboros/moltbook.py
+++ b/src/ouroboros/moltbook.py
@@ -273,11 +273,33 @@ class RunnerConfig:
     reviewer_api_key: Optional[str] = field(default=None, repr=False)
 
 
+def _warn_unknown_config_keys(data: Dict[str, Any], path: str) -> None:
+    """Name every agent.json key that is not a setting at all.
+
+    Every setting below is pulled out by name, so a typo, a stale key, or a
+    SafetyConfig cap that is a compile-time constant parses cleanly and then
+    does nothing: the operator sees a saved file and keeps the old limit.
+    config_schema was written to stop exactly that, and was wired to
+    `config set` and to comment suggestions but not to the file the README
+    calls the runtime config.
+
+    A warning, not a refusal. The agent runs unattended, and one unrecognised
+    key must not keep the rest of a valid config from starting.
+    """
+    from . import config_schema
+
+    for key in data:
+        error = config_schema.unknown_key_error(key)
+        if error:
+            log.warning("%s: %s -- ignored, this setting has no effect", path, error)
+
+
 def load_runner_config() -> RunnerConfig:
     cfg_path = os.path.expanduser("~/.config/moltbook/agent.json")
     data: Dict[str, Any] = {}
     if os.path.exists(cfg_path):
         data = _read_json_file(cfg_path)
+        _warn_unknown_config_keys(data, cfg_path)
 
     # Keep sensitive Telegram values out of tracked config.
     cred_path = os.path.expanduser("~/.config/moltbook/credentials.json")

--- a/tests/test_moltbook.py
+++ b/tests/test_moltbook.py
@@ -999,3 +999,40 @@ def test_get_my_posts_skips_a_record_with_a_malformed_author(bad):
     mine = {"id": "2", "author": {"name": "agent"}}
     with mock.patch("ouroboros.moltbook.get_feed", return_value={"posts": [bad, mine]}):
         assert get_my_posts("key", "agent") == [mine]
+
+
+def test_load_runner_config_names_the_keys_it_ignores(tmp_path, caplog):
+    """An unread key is worse than a rejected one.
+
+    Every setting is pulled out of the file by name, so a typo -- or a cap
+    that is a compile-time constant rather than a runner setting -- parses
+    cleanly and then does nothing. The operator sees a saved file and keeps
+    the old limit.
+    """
+    with caplog.at_level("WARNING"):
+        cfg = _runner_config_from(
+            tmp_path,
+            {
+                "interval_seconds": 60,
+                "intervals_seconds": 30,
+                "max_lines_changed_per_pr": 500,
+            },
+        )
+
+    # The keys that are real still apply: one bad key does not stop startup.
+    assert cfg.interval_seconds == 60
+    assert "intervals_seconds" in caplog.text
+    assert "did you mean interval_seconds?" in caplog.text
+    assert "max_lines_changed_per_pr" in caplog.text
+
+
+def test_load_runner_config_is_quiet_about_a_valid_file(tmp_path, caplog):
+    """The warning has to stay rare enough to be worth reading."""
+    with caplog.at_level("WARNING"):
+        cfg = _runner_config_from(
+            tmp_path,
+            {"interval_seconds": 60, "max_improvements_per_day": 5, "keyword_allowlist": None},
+        )
+
+    assert cfg.max_improvements_per_day == 5
+    assert caplog.text == ""


### PR DESCRIPTION
## Problem

`config_schema.validate` exists to stop a mistyped setting from being silently
ignored -- its docstring says so -- but it was wired to exactly two callers:
`ouroboros config set` (`cli.py:108`) and the comment-suggestion path
(`self_modify.py:73`). Neither is how the agent is actually configured.

`moltbook.load_runner_config` reads `~/.config/moltbook/agent.json` -- the file
the README calls the runtime config -- and pulls every known key out with
`data.get(...)`, dropping everything else on the floor. No unknown-key check,
no log line.

So a typo, a stale key, or a `SafetyConfig` cap that is a compile-time constant
rather than a runner setting parses cleanly and then does nothing. Raise
`max_lines_changed_per_pr` to 500 in `agent.json` and the cap stays 200:
improvements keep getting rejected for size and nothing anywhere says why.

## Fix

`load_runner_config` now runs every key of the parsed file through
`config_schema` and logs each one that is not a setting, reusing the same
`did you mean ...?` hint `config set` already produces. `unknown_key_error` is
split out of `validate` so the two paths cannot drift; `validate` calls it, so
the message shape is unchanged.

A warning, not a refusal to start. The agent runs unattended on the Pi, and one
unrecognised key must not keep the rest of a valid config from loading. The
tracked `config/agent.json` -- which on the Pi *is* the live config -- contains
no unknown keys (already guarded by
`test_every_tracked_config_key_is_a_known_setting`), so nothing valid starts
warning.

Not included: the issue's second suggestion, annotating the generated
`SafetyConfig` table in `wiki.py:241` with where each field can be set. That is
a docs-generation change with its own surface; the loader gap is the one that
silently loses an operator's edit.

## Test evidence

New in `tests/test_moltbook.py`:

- `test_load_runner_config_names_the_keys_it_ignores` -- fails on `main`
  (`AssertionError: assert 'intervals_seconds' in ''`), passes here. Asserts
  the typo and `max_lines_changed_per_pr` are both named, the did-you-mean hint
  appears, and the valid keys in the same file still apply.
- `test_load_runner_config_is_quiet_about_a_valid_file` -- a config of real
  settings logs nothing, so the warning stays worth reading.

Full suite from the worktree root:

```
PYTHONPATH=src python -m pytest tests/ -q
1123 passed in 7.47s
```

(1121 on this branch's base `fd49d8b5` = `origin/main`, plus the 2 new tests.)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJo9JBknnTZfzmpKUBU9kM

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->