### PR TITLE
fix(git_ops): refuse to merge PRs without CI, and read an empty check list as pending

### DIFF
--- a/src/ouroboros/git_ops.py
+++ b/src/ouroboros/git_ops.py
@@ -401,8 +401,11 @@ def get_pr_status(repo: Path, branch: str) -> Optional[str]:
 def auto_merge_pr(repo: Path, pr_url: str, strategy: str = "squash") -> bool:
     """Enable auto-merge on a PR. Returns True on success.
 
-    Uses --auto so the PR merges once all checks pass.
-    Falls back to immediate merge if auto-merge is not available on the repo.
+    Uses --auto so the PR merges once all checks pass. When the repository has
+    auto-merge disabled there is no safe fallback: merging without --auto lands
+    the PR immediately, before CI has had a chance to run, which is the opposite
+    of what this function promises. In that case it refuses and returns False,
+    leaving the PR open for a human to merge.
     """
     try:
         subprocess.run(
@@ -416,24 +419,19 @@ def auto_merge_pr(repo: Path, pr_url: str, strategy: str = "squash") -> bool:
         log.info("Auto-merge enabled for PR: %s", pr_url)
         return True
     except subprocess.CalledProcessError as e:
-        # --auto may not be available (requires branch protection), try immediate merge
-        if "auto-merge" in e.stderr.lower() or "not allowed" in e.stderr.lower():
-            log.info("Auto-merge not available, attempting immediate merge for %s", pr_url)
-            try:
-                subprocess.run(
-                    ["gh", "pr", "merge", pr_url, f"--{strategy}"],
-                    cwd=repo,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    timeout=60,
-                )
-                log.info("Immediately merged PR: %s", pr_url)
-                return True
-            except subprocess.CalledProcessError:
-                log.warning("Immediate merge also failed for %s", pr_url)
-                return False
-        log.warning("Failed to enable auto-merge for %s: %s", pr_url, e.stderr.strip())
+        stderr = e.stderr or ""
+        # --auto requires allow_auto_merge on the repository. Without it the
+        # only remaining option is an unguarded `gh pr merge`, which merges now
+        # and waits for nothing -- so refuse rather than skip the checks.
+        if "auto-merge" in stderr.lower() or "not allowed" in stderr.lower():
+            log.error(
+                "Auto-merge is disabled on this repository; refusing to merge %s "
+                "without waiting for checks. Leaving the PR open. Enable it with: "
+                "gh api -X PATCH repos/OWNER/REPO -f allow_auto_merge=true",
+                pr_url,
+            )
+            return False
+        log.warning("Failed to enable auto-merge for %s: %s", pr_url, stderr.strip())
         return False
     except (FileNotFoundError, subprocess.TimeoutExpired):
         log.warning("Could not auto-merge PR %s (gh CLI unavailable or timeout)", pr_url)
@@ -443,21 +441,34 @@ def auto_merge_pr(repo: Path, pr_url: str, strategy: str = "squash") -> bool:
 def get_pr_checks_status(repo: Path, pr_url: str) -> Optional[str]:
     """Get the combined CI checks status for a PR.
 
-    Returns 'pass', 'fail', 'pending', or None.
+    Returns 'pass', 'fail', 'pending', or None when the status is unknown.
+
+    An empty check list means the checks have not started, not that they
+    passed: jq's all() is true on an empty array, so the query tests length
+    first. gh signals the same thing out of band -- it exits 8 while checks
+    are pending and 1 with "no checks reported" when a PR has none at all,
+    printing nothing on stdout in either case. Neither is a green PR, so both
+    read 'pending'.
     """
     try:
         result = subprocess.run(
             ["gh", "pr", "checks", pr_url, "--json", "state", "-q",
-             '[.[] | .state] | if all(. == "SUCCESS") then "pass" elif any(. == "FAILURE") then "fail" else "pending" end'],
+             '[.[] | .state] | if length == 0 then "pending"'
+             ' elif any(. == "FAILURE") then "fail"'
+             ' elif all(. == "SUCCESS") then "pass" else "pending" end'],
             cwd=repo,
             capture_output=True,
             text=True,
-            check=True,
             timeout=30,
         )
-        return result.stdout.strip() or None
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return None
+    status = (result.stdout or "").strip()
+    if status in ("pass", "fail", "pending"):
+        return status
+    if result.returncode == 8 or "no checks reported" in (result.stderr or "").lower():
+        return "pending"
+    return None
 
 
 def get_pr_feedback(repo: Path, pr_url: str, max_chars: int = 2000) -> Optional[str]:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,5 +1,7 @@
 """Tests for git_ops module."""
 
+import json
+import shutil
 import subprocess
 import time
 from unittest.mock import patch, MagicMock
@@ -9,6 +11,8 @@ from pathlib import Path
 
 from ouroboros.git_ops import (
     _decode_git_path,
+    auto_merge_pr,
+    get_pr_checks_status,
     get_pr_feedback,
     get_pr_status,
     has_open_improvement_prs,
@@ -309,8 +313,8 @@ def test_commit_auto_state_ignores_sibling_of_state_file(mock_git, mock_branch):
 
 # -- has_open_improvement_prs ------------------------------------------------
 
-def _completed(stdout="", returncode=0):
-    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+def _completed(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
 
 
 @patch("ouroboros.git_ops.subprocess.run")
@@ -561,3 +565,162 @@ def test_has_open_improvement_prs_saturated_page_is_unknown(mock_run):
 def test_has_open_improvement_prs_short_page_is_definitive(mock_run):
     mock_run.return_value = _completed("\n".join(f"feature/pr-{i}" for i in range(5)))
     assert has_open_improvement_prs(Path("/repo")) is False
+
+
+# -- auto_merge_pr -----------------------------------------------------------
+
+def _gh_error(stderr):
+    err = subprocess.CalledProcessError(1, ["gh", "pr", "merge"])
+    err.stderr = stderr
+    return err
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_auto_merge_pr_uses_auto(mock_run):
+    mock_run.return_value = _completed("")
+    assert auto_merge_pr(Path("/repo"), "https://gh/pr/1") is True
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd[:3] == ["gh", "pr", "merge"]
+    assert "--auto" in cmd
+    assert "--squash" in cmd
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "X GraphQL: Auto-merge is not allowed for this repository (enablePullRequestAutoMerge)",
+        "Pull request Auto-merge is not allowed for this repository",
+    ],
+)
+@patch("ouroboros.git_ops.subprocess.run")
+def test_auto_merge_pr_refuses_to_merge_without_checks(mock_run, stderr):
+    """No --auto means no CI gate, so the PR must be left open, not merged.
+
+    The old fallback ran a bare `gh pr merge`, which merges immediately and
+    waits for nothing -- on a repo with allow_auto_merge=false that was the
+    only reachable path, so every autonomous PR landed unchecked.
+    """
+    mock_run.side_effect = [_gh_error(stderr), _completed("")]
+
+    assert auto_merge_pr(Path("/repo"), "https://gh/pr/1") is False
+    # The second side_effect entry must never be consumed: exactly one
+    # `gh pr merge` attempt, the one carrying --auto.
+    assert mock_run.call_count == 1
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_auto_merge_pr_unrelated_failure_returns_false(mock_run):
+    mock_run.side_effect = _gh_error("could not resolve to a PullRequest")
+    assert auto_merge_pr(Path("/repo"), "https://gh/pr/1") is False
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_auto_merge_pr_tolerates_missing_stderr(mock_run):
+    mock_run.side_effect = _gh_error(None)
+    assert auto_merge_pr(Path("/repo"), "https://gh/pr/1") is False
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        FileNotFoundError("gh not installed"),
+        subprocess.TimeoutExpired(["gh"], 30),
+    ],
+)
+@patch("ouroboros.git_ops.subprocess.run")
+def test_auto_merge_pr_gh_unavailable(mock_run, error):
+    mock_run.side_effect = error
+    assert auto_merge_pr(Path("/repo"), "https://gh/pr/1") is False
+
+
+# -- get_pr_checks_status ----------------------------------------------------
+
+@pytest.mark.parametrize("status,returncode", [("pass", 0), ("fail", 1), ("pending", 8)])
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_checks_status_returns_the_bucket(mock_run, status, returncode):
+    # gh exits non-zero for anything but a green PR (8 while pending) and
+    # still prints the jq result.
+    mock_run.return_value = _completed(f"{status}\n", returncode=returncode)
+    assert get_pr_checks_status(Path("/repo"), "https://gh/pr/1") == status
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_checks_status_no_checks_is_pending(mock_run):
+    """A PR with no checks has not passed anything.
+
+    `gh pr checks` exits 1 and prints nothing on stdout in this case, so the
+    absence of output must not read as "pass" -- nor as "unknown".
+    """
+    mock_run.return_value = _completed(
+        "", returncode=1, stderr="no checks reported on the 'ouroboros/x' branch\n"
+    )
+    assert get_pr_checks_status(Path("/repo"), "https://gh/pr/1") == "pending"
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_checks_status_exit_8_is_pending(mock_run):
+    """Exit code 8 is gh's documented "checks pending"."""
+    mock_run.return_value = _completed("", returncode=8)
+    assert get_pr_checks_status(Path("/repo"), "https://gh/pr/1") == "pending"
+
+
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_checks_status_unknown_stays_none(mock_run):
+    mock_run.return_value = _completed("", returncode=1, stderr="authentication failed\n")
+    assert get_pr_checks_status(Path("/repo"), "https://gh/pr/1") is None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        FileNotFoundError("gh not installed"),
+        subprocess.TimeoutExpired(["gh"], 30),
+    ],
+)
+@patch("ouroboros.git_ops.subprocess.run")
+def test_get_pr_checks_status_gh_unavailable(mock_run, error):
+    mock_run.side_effect = error
+    assert get_pr_checks_status(Path("/repo"), "https://gh/pr/1") is None
+
+
+def _checks_jq_query():
+    """The jq expression get_pr_checks_status hands to `gh pr checks -q`."""
+    with patch("ouroboros.git_ops.subprocess.run") as mock_run:
+        mock_run.return_value = _completed("pass")
+        get_pr_checks_status(Path("/repo"), "https://gh/pr/1")
+    cmd = mock_run.call_args.args[0]
+    return cmd[cmd.index("-q") + 1]
+
+
+@pytest.mark.parametrize(
+    "states,expected",
+    [
+        ([], "pending"),
+        (["SUCCESS"], "pass"),
+        (["SUCCESS", "SUCCESS"], "pass"),
+        (["SUCCESS", "FAILURE"], "fail"),
+        (["FAILURE"], "fail"),
+        (["SUCCESS", "IN_PROGRESS"], "pending"),
+        (["QUEUED"], "pending"),
+    ],
+)
+def test_checks_jq_query_semantics(states, expected):
+    """Run the real jq expression: an empty check list must not read "pass".
+
+    jq's all() is true on an empty array, so `all(. == "SUCCESS")` on its own
+    calls a PR whose checks have not started green.
+    """
+    jq = shutil.which("jq")
+    if jq is None:
+        pytest.skip("jq not installed")
+
+    out = subprocess.run(
+        [jq, "-r", _checks_jq_query()],
+        input=json.dumps([{"state": s} for s in states]),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    assert out.stdout.strip() == expected


### PR DESCRIPTION
## Problem

**#116 — `auto_merge_pr` merged without ever waiting for CI.** The `except` branch is not a fallback on this repository, it is the only path. `gh pr merge --auto` fails whenever `allow_auto_merge` is false (it is: `gh api repos/theanhgen/ouroboros --jq '.allow_auto_merge'` → `false`), and the error text contains both `"auto-merge"` and `"not allowed"`, so the `if` matched every time and control always reached an unguarded `gh pr merge --squash`. That command merges now and waits for nothing; with `main` unprotected nothing else stopped it. Autonomous PRs landed in ~4s against a Tests workflow that takes 44–69s.

**#80 — `get_pr_checks_status` called an empty check set green.** jq's `all()` is true on an empty array, so `[.[] | .state] | if all(. == "SUCCESS") then "pass" …` returned `"pass"` for a PR whose checks had not started:

```
$ echo '[]' | jq -r '[.[] | .state] | if all(. == "SUCCESS") then "pass" elif any(. == "FAILURE") then "fail" else "pending" end'
pass
```

While verifying that, a second half of the same bug turned up: `gh pr checks` signals the condition out of band too, and `check=True` was swallowing it. `gh` exits 8 while checks are pending and exits 1 printing `no checks reported on the '<branch>' branch` when a PR has none at all — both raised `CalledProcessError`, so pending and failing check sets came back as `None`.

## Fix

`src/ouroboros/git_ops.py`, two functions, no other files touched.

- `auto_merge_pr`: when `--auto` is unavailable, log an error naming the repo setting to enable and return `False`. No second merge attempt. Leaving the PR open is the correct degradation — `pr_only` is satisfied, a human can merge it, and nothing unreviewed lands. `improvement.py:1304` only fires `auto_merged` on a `True` return, so the Telegram notification no longer claims a merge that skipped CI.
- `get_pr_checks_status`: the jq query tests `length == 0` first, so an empty check list reads `"pending"`. `check=True` is dropped in favour of inspecting the result, so exit 8 and `no checks reported` also read `"pending"`, a failing set reads `"fail"`, and only a genuinely unrecognised failure stays `None`.

Deliberately **not** changed: `enable_auto_merge` still defaults to `True` in `config.py`. #116 suggested flipping it, but that was contingent on the flag meaning "merge immediately"; with this fix `True` means "queue behind checks, refuse if that is impossible", which is what `config.py:25` and `wiki.py:233` already document.

## Test evidence

22 new tests in `tests/test_git_ops.py`. Reverting only `src/ouroboros/git_ops.py` and re-running fails exactly these:

```
FAILED tests/test_git_ops.py::test_auto_merge_pr_refuses_to_merge_without_checks[X GraphQL: Auto-merge is not allowed for this repository (enablePullRequestAutoMerge)]
FAILED tests/test_git_ops.py::test_auto_merge_pr_refuses_to_merge_without_checks[Pull request Auto-merge is not allowed for this repository]
FAILED tests/test_git_ops.py::test_auto_merge_pr_tolerates_missing_stderr
FAILED tests/test_git_ops.py::test_get_pr_checks_status_no_checks_is_pending
FAILED tests/test_git_ops.py::test_get_pr_checks_status_exit_8_is_pending
FAILED tests/test_git_ops.py::test_checks_jq_query_semantics[states0-pending]
6 failed, 90 passed in 0.29s
```

`test_auto_merge_pr_refuses_to_merge_without_checks` is the one that pins #116: `subprocess.run` is given a two-element `side_effect`, and the test asserts the second entry is never consumed — the old code consumed it and returned `True`. `test_checks_jq_query_semantics` pins #80 by running the real jq expression that ships in the command, empty array included.

Full suite on this branch:

```
1143 passed in 8.02s
```

(1121 on `fd49d8b5` before the change, +22.)

## Operational note

With auto-merge off at the repo level, the agent will now leave its PRs open, and `has_open_improvement_prs` will stop the next cycle until a human merges. To restore hands-off landing *safely*, enable it and require the `test` checks on `main`:

```
gh api -X PATCH repos/theanhgen/ouroboros -f allow_auto_merge=true
```

Then `--auto` succeeds and the PR merges when CI goes green, as the docstring always claimed.

Closes #116
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJo9JBknnTZfzmpKUBU9kM

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->