### PR TITLE
fix(metrics): quarantine an unreadable metrics.json instead of overwriting it (#115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ htmlcov/
 # Untracked, they made the worktree permanently dirty, and the runner refuses
 # to act from a dirty tree -- so the agent skipped every cycle from 2026-08-10.
 *.pre-sqlite
+
+# Unreadable state files moved aside instead of being overwritten (metrics.py).
+# Ignored for the same reason as above: the point of keeping the damaged copy
+# is to be able to recover from it, not to stop every later cycle.
+*.json.corrupt-*

--- a/src/ouroboros/metrics.py
+++ b/src/ouroboros/metrics.py
@@ -17,6 +17,49 @@ def _metrics_path(repo_root: Path) -> Path:
     return repo_root / METRICS_FILE
 
 
+def _coerce_snapshots(data: Any) -> Optional[List[Dict[str, Any]]]:
+    """Return the snapshot list in a loaded document, or None if it holds none.
+
+    None and [] are different answers and the difference matters on the write
+    path: [] means "a readable file with no snapshots yet", None means "this
+    document is not a metrics file", and only the first is safe to append to
+    and write back.
+    """
+    if isinstance(data, dict):
+        snapshots = data.get("snapshots")
+    elif isinstance(data, list):
+        # The original on-disk shape was a bare list. Still readable.
+        snapshots = data
+    else:
+        snapshots = None
+    return snapshots if isinstance(snapshots, list) else None
+
+
+def _quarantine_corrupt(path: Path) -> Path:
+    """Move an unreadable metrics file aside instead of letting it be rewritten.
+
+    A history that cannot be parsed is still worth more sitting on disk than
+    replaced by a single fresh row: the file is the only copy, config/ is
+    auto-committed every cycle, and a truncated series is indistinguishable
+    from an agent that has just run for the first time.
+
+    Failing to move it aside raises rather than falling through, because the
+    caller's next step is the write that would destroy it.
+    """
+    stamp = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+    dest = path.with_name(f"{path.name}.corrupt-{stamp}")
+    suffix = 1
+    while dest.exists():
+        dest = path.with_name(f"{path.name}.corrupt-{stamp}-{suffix}")
+        suffix += 1
+    os.replace(path, dest)
+    log.error(
+        "%s could not be read and was moved to %s; the history it held is not "
+        "in the new file", path, dest.name,
+    )
+    return dest
+
+
 def load_metrics(repo_root: Path) -> List[Dict[str, Any]]:
     path = _metrics_path(repo_root)
     if not path.exists():
@@ -24,15 +67,10 @@ def load_metrics(repo_root: Path) -> List[Dict[str, Any]]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        if isinstance(data, dict):
-            snapshots = data.get("snapshots")
-        elif isinstance(data, list):
-            snapshots = data
-        else:
-            snapshots = None
-        return snapshots if isinstance(snapshots, list) else []
     except (json.JSONDecodeError, KeyError):
         return []
+    snapshots = _coerce_snapshots(data)
+    return snapshots if snapshots is not None else []
 
 
 def save_metrics(repo_root: Path, snapshots: List[Dict[str, Any]]) -> None:
@@ -134,6 +172,40 @@ def _policy_metrics(improvement_result: Any) -> Dict[str, Dict[str, Any]]:
     return metrics
 
 
+def _append_snapshot(repo_root: Path, snapshot: Dict[str, Any]) -> None:
+    """Add one snapshot to the history, under the storage lock.
+
+    load-append-save as three statements lets a second process write between
+    the load and the save, dropping whichever record was appended first, and --
+    worse -- makes load_metrics' "return [] for a file I cannot read" into a
+    wholesale truncation, because the empty list is written straight back over
+    the file it came from. update_json_file closes the race; the quarantine
+    hook and the None check below keep an unreadable history off the write
+    path entirely.
+    """
+    from .storage import update_json_file
+
+    path = _metrics_path(repo_root)
+
+    def append(data: Any) -> Dict[str, Any]:
+        snapshots = _coerce_snapshots(data)
+        if snapshots is None:
+            # Parsed, but not a metrics document. Same treatment as a parse
+            # failure: whatever it is, it is not ours to overwrite.
+            _quarantine_corrupt(path)
+            snapshots = []
+        snapshots.append(snapshot)
+        return {"snapshots": snapshots[-MAX_SNAPSHOTS:]}
+
+    update_json_file(
+        path,
+        append,
+        default={"snapshots": []},
+        replace=True,
+        on_corrupt=_quarantine_corrupt,
+    )
+
+
 def record_snapshot(
     repo_root: Path,
     improvement_result: Any = None,
@@ -189,9 +261,7 @@ def record_snapshot(
             snapshot["tests_failed"] = test_after.failed
         snapshot.update(_policy_metrics(improvement_result))
 
-    snapshots = load_metrics(repo_root)
-    snapshots.append(snapshot)
-    save_metrics(repo_root, snapshots)
+    _append_snapshot(repo_root, snapshot)
 
     log.info(
         "[metrics] Snapshot: %d src LOC, %d test LOC, %.1f%% success rate (30d)",

--- a/src/ouroboros/storage.py
+++ b/src/ouroboros/storage.py
@@ -151,6 +151,7 @@ def update_json_file(
     sort_keys: bool = False,
     indent: int = 2,
     replace: bool = False,
+    on_corrupt: Optional[Callable[[Path], Any]] = None,
 ) -> Any:
     """Load, apply mutate, and write back, all under one lock.
 
@@ -167,6 +168,12 @@ def update_json_file(
     With ``replace``, what mutate returns is written instead -- needed when the
     root value itself has to change, such as normalising a corrupt document of
     the wrong type before appending to it.
+
+    ``on_corrupt`` is called with the path, still under the lock, when the file
+    is there but cannot be parsed. Starting from the default means the write
+    that follows replaces whatever the damaged file held, so a caller whose
+    file is the only copy of its history can use the hook to move it aside
+    first. Raising from the hook aborts the update and leaves the file alone.
     """
     json_path = Path(path).expanduser()
     with _directory_lock(json_path.parent):
@@ -177,6 +184,8 @@ def update_json_file(
             data = copy.deepcopy(default)
         except (json.JSONDecodeError, UnicodeDecodeError):
             log.warning("Corrupt %s; starting from the default", json_path)
+            if on_corrupt is not None:
+                on_corrupt(json_path)
             data = copy.deepcopy(default)
 
         result = mutate(data)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -99,6 +99,111 @@ class TestMetrics:
         assert snapshot["policy_size"]["num_lines"] == 2
         assert snapshot["policy_size"]["max_lines"] == 200
 
+    @patch("ouroboros.evaluation.load_history")
+    def test_record_snapshot_appends_to_existing_history(self, mock_load_history):
+        mock_load_history.return_value = []
+        save_metrics(self.tmp_dir, [{"timestamp": 1, "src_lines": 7}])
+
+        record_snapshot(self.tmp_dir)
+
+        loaded = load_metrics(self.tmp_dir)
+        assert len(loaded) == 2
+        assert loaded[0]["src_lines"] == 7
+
+    @patch("ouroboros.evaluation.load_history")
+    def test_record_snapshot_appends_to_a_bare_list_file(self, mock_load_history):
+        # The original on-disk shape. Readable, so it must not be quarantined.
+        mock_load_history.return_value = []
+        path = self.config_dir / "metrics.json"
+        path.write_text(json.dumps([{"timestamp": 1, "src_lines": 7}]), "utf-8")
+
+        record_snapshot(self.tmp_dir)
+
+        assert len(load_metrics(self.tmp_dir)) == 2
+        assert list(self.config_dir.glob("metrics.json.corrupt-*")) == []
+
+    @patch("ouroboros.evaluation.load_history")
+    def test_record_snapshot_quarantines_an_unreadable_file(self, mock_load_history):
+        # The regression: load_metrics returns [] for a file it cannot parse,
+        # and appending to that [] used to overwrite the history wholesale --
+        # then config/metrics.json is auto-committed, so the loss is pushed.
+        mock_load_history.return_value = []
+        path = self.config_dir / "metrics.json"
+        damaged = '{"snapshots": [{"timestamp": 1, "src_l'
+        path.write_text(damaged, encoding="utf-8")
+
+        record_snapshot(self.tmp_dir)
+
+        quarantined = list(self.config_dir.glob("metrics.json.corrupt-*"))
+        assert len(quarantined) == 1, "the damaged history was not kept"
+        assert quarantined[0].read_text(encoding="utf-8") == damaged
+        assert len(load_metrics(self.tmp_dir)) == 1
+
+    @patch("ouroboros.evaluation.load_history")
+    def test_record_snapshot_quarantines_a_wrong_shaped_file(self, mock_load_history):
+        # Parses, but carries no snapshot list: still not ours to overwrite.
+        mock_load_history.return_value = []
+        path = self.config_dir / "metrics.json"
+        damaged = '{"snapshots": {"1": {"src_lines": 7}}}'
+        path.write_text(damaged, encoding="utf-8")
+
+        record_snapshot(self.tmp_dir)
+
+        quarantined = list(self.config_dir.glob("metrics.json.corrupt-*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].read_text(encoding="utf-8") == damaged
+        assert len(load_metrics(self.tmp_dir)) == 1
+
+    @patch("ouroboros.evaluation.load_history")
+    def test_two_quarantines_in_one_second_do_not_collide(self, mock_load_history):
+        mock_load_history.return_value = []
+        path = self.config_dir / "metrics.json"
+
+        for raw in ("first-damaged", "second-damaged"):
+            path.write_text(raw, encoding="utf-8")
+            record_snapshot(self.tmp_dir)
+
+        kept = sorted(
+            p.read_text(encoding="utf-8")
+            for p in self.config_dir.glob("metrics.json.corrupt-*")
+        )
+        assert kept == ["first-damaged", "second-damaged"]
+
+    @patch("ouroboros.evaluation.load_history")
+    def test_record_snapshot_keeps_the_history_bounded(self, mock_load_history):
+        mock_load_history.return_value = []
+        save_metrics(self.tmp_dir, [{"timestamp": i} for i in range(200)])
+
+        record_snapshot(self.tmp_dir)
+
+        loaded = load_metrics(self.tmp_dir)
+        assert len(loaded) == 200
+        assert loaded[0]["timestamp"] == 1  # the oldest was dropped
+
+    @patch("ouroboros.evaluation.load_history")
+    def test_concurrent_snapshots_do_not_lose_records(self, mock_load_history):
+        """load-append-save as three steps drops whichever write landed first."""
+        import threading
+
+        mock_load_history.return_value = []
+        errors = []
+
+        def writer():
+            try:
+                for _ in range(5):
+                    record_snapshot(self.tmp_dir)
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert len(load_metrics(self.tmp_dir)) == 20
+
     def test_get_summary_empty(self):
         summary = get_summary(self.tmp_dir)
         assert summary == "No metrics recorded yet."

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -624,6 +624,62 @@ def test_update_json_file_recovers_from_a_corrupt_file(tmp_path):
     assert load_json_file(path) == {"items": ["a"]}
 
 
+def test_on_corrupt_runs_before_the_default_replaces_the_file(tmp_path):
+    path = tmp_path / "x.json"
+    path.write_text("{ not json")
+    seen = []
+
+    def keep(p):
+        seen.append(p.read_text(encoding="utf-8"))
+
+    update_json_file(
+        path,
+        lambda d: d["items"].append("a"),
+        default={"items": []},
+        on_corrupt=keep,
+    )
+
+    assert seen == ["{ not json"]
+    assert load_json_file(path) == {"items": ["a"]}
+
+
+@pytest.mark.parametrize("contents", [None, '{"items": ["existing"]}'])
+def test_on_corrupt_is_only_for_files_that_cannot_be_read(tmp_path, contents):
+    path = tmp_path / "x.json"
+    if contents is not None:
+        path.write_text(contents)
+    calls = []
+
+    update_json_file(
+        path,
+        lambda d: d["items"].append("a"),
+        default={"items": []},
+        on_corrupt=calls.append,
+    )
+
+    assert calls == []
+
+
+def test_a_raising_on_corrupt_leaves_the_damaged_file_alone(tmp_path):
+    """The hook exists to protect the file; a failure must not write over it."""
+    path = tmp_path / "x.json"
+    path.write_text("{ not json")
+
+    def refuse(p):
+        raise OSError("cannot move it aside")
+
+    with pytest.raises(OSError):
+        update_json_file(
+            path,
+            lambda d: d["items"].append("a"),
+            default={"items": []},
+            on_corrupt=refuse,
+        )
+
+    assert path.read_text() == "{ not json"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
 def test_update_json_file_does_not_write_when_mutate_raises(tmp_path):
     path = tmp_path / "x.json"
     save_json_file(path, {"items": ["original"]})


### PR DESCRIPTION
## Problem

`record_snapshot` recorded a snapshot as a load-modify-save across three statements:

```python
snapshots = load_metrics(repo_root)
snapshots.append(snapshot)
save_metrics(repo_root, snapshots)   # replaces the file wholesale
```

`load_metrics` deliberately returns `[]` for a file it cannot parse — correct for readers (`get_summary`, `wiki.generate_metrics_page`), wrong for the writer that is about to overwrite the file. One torn or truncated write to `config/metrics.json` therefore turned the entire history into a single fresh row. `config/metrics.json` is on `_AUTO_STATE_FILES` (`git_ops.py:143`), so the loop committed and pushed that loss with no error and no log line, and `MAX_SNAPSHOTS` trimming means a short series is not suspicious on its own. The same three statements are also the lost-update race `storage.update_json_file` exists to prevent.

## Fix

- `record_snapshot` appends through `storage.update_json_file`, so the read and the write happen under one directory lock and a concurrent writer cannot drop a record.
- `update_json_file` gains an optional `on_corrupt` hook, called with the path **under the lock** before the default takes over. Default is `None`, so every existing caller is unchanged.
- `metrics._quarantine_corrupt` renames the damaged file to `metrics.json.corrupt-<ts>` and logs an error, rather than letting the next write replace it. A document that parses but carries no snapshot list (`{"snapshots": {...}}`) gets the same treatment; a bare list, the original on-disk shape, is still read normally. If the file cannot be moved aside the update raises rather than writing, because the write is what would destroy it.
- `.gitignore` ignores `*.json.corrupt-*`, for the reason the `*.pre-sqlite` entry already records: an untracked file in `config/` makes the worktree permanently dirty and `improvement_runner` then skips every cycle. The quarantined copy is meant to allow recovery, not to stall the agent.

`load_metrics`' shape handling is now shared with the write path as `_coerce_snapshots`, which returns `None` (not `[]`) for a document that is not a metrics file — the distinction the writer needs and the reader does not.

Note: `record_snapshot` currently has no production caller on `main` (only tests and `docs/wiki/architecture.md`), so this is a latent defect rather than an active one — but `config/metrics.json` is tracked, populated, and auto-committed, so it becomes live again the moment the loop calls it.

## Test evidence

Four new tests fail on `fd49d8b5` and pass here:

- `test_record_snapshot_quarantines_an_unreadable_file` — the regression: asserts the damaged bytes survive in `metrics.json.corrupt-*`. Before: no quarantine file, history gone.
- `test_record_snapshot_quarantines_a_wrong_shaped_file`
- `test_two_quarantines_in_one_second_do_not_collide`
- `test_concurrent_snapshots_do_not_lose_records` — 4 threads x 5 appends; before the change this raised `FileNotFoundError` from the shared `<name>.tmp` and lost records.

Plus guards that pass both before and after (`..._appends_to_existing_history`, `..._appends_to_a_bare_list_file`, `..._keeps_the_history_bounded`) and four `on_corrupt` tests in `tests/test_storage.py`.

Before, on this branch's base:
```
4 failed, 10 passed in 0.42s
```

Full suite after:
```
1132 passed in 7.58s
```
(baseline on `fd49d8b5` is `1121 passed`; +11 new cases, zero failures)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJo9JBknnTZfzmpKUBU9kM

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theanhgen/ouroboros/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->